### PR TITLE
Updated installation documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,8 @@ On Linux this will build apexpy from source, which requires a fortran compiler s
 
 The package has been tested with the following setups (others might work, too):
 
-* Windows (32/64 bit Python), Linux (64 bit), and Mac
-* Python 2.7, 3.3, 3.4 (and 3.5 on Linux/Mac [2]_)
+* Windows (64 bit Python), Linux (64 bit), and Mac (64 bit)
+* Python 2.7, 3.3 (also 32 bit Windows), 3.5 (and 3.4 on Linux/Mac [2]_)
 
 .. [1] pip is included with Python 2 from v2.7.9 and Python 3 from v3.4. If you don't have pip, `get it here <http://pip.readthedocs.org/en/stable/installing/>`_.
-.. [2] I do not know of any way to compile the Fortran extension on Windows in a manner that is compatible with Python 3.5. If you get it working, let me know!
+.. [2] I do not know how to compile the Fortran extension on Windows in a manner that is compatible with the omitted python versions. If you get it working, let me know!


### PR DESCRIPTION
Updated installation documentation.  AppVeyor shows that Windows 32 bit
only compiles the fortran code in python 3.3, and python 3.4 doesn’t
compile at all.