### PR TITLE
Remove hidden dependency on libgfortran

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ if environ.get('READTHEDOCS', None) == 'True':
     extensions = []
 else:
     from numpy.distutils.core import setup, Extension
+    
+    # Statically link libgfortran so users don't need to install it
+    environ['LDFLAGS']='-static-libgfortran'
+    environ['FFLAGS']='-O3 -fPIC -static-libgfortran'
+    
     extensions = [
         Extension(name='apexpy.fortranapex',
                   sources=['src/fortranapex/magfld.f', 'src/fortranapex/apex.f',


### PR DESCRIPTION
Fixes issue #10 

Set Fortran environment variables to statically include libgfortran in the fortranapex.so library so that users don't need to install libgfortran.

This was tested on Cent OS7 by:

    pip install .

and then checking the `fortranapex.so` file with `ldd` to see if there was a reference to `libgfortran`.

I cannot test this on Mac OSX nor Windows.