### PR TITLE
Include better installation instructions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ This python wrapper is made by:
 * Karl M. Laundal
 * Christer van der Meeren
 * Angeline G. Burrell (maintainer)
+* Ashton Reimer
 
 Fortran code by Emmert et al. [2010] [1]_. Quasi-dipole and modified
 apex coordinates are defined by Richmond [1995] [2]_. The code uses

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.0.4 (2019-04-05)
+----------------------------------------
+* Updated installation instructions
+* Simplified warning tests
+* Made some PEP8 changes
+
 1.0.3 (2018-04-05)
 -----------------------------------------
 * Updated badges and added DOI

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,12 @@ Install (requires NumPy before installation)::
 
     pip install apexpy
 
+This assumes that the same version of libgfortran is installed in the same location as when the pip wheel was built. If not, you may have trouble importing apexpy and you will have to build apexpy yourself using::
+
+    pip install --global-option='build_ext' apexpy
+    
+which requires both libgfortran and gfortran to be installed on your system.
+
 Conversion is done by creating an ``Apex`` object and using its methods to
 perform the desired calculations. Some simple examples::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,8 +13,11 @@ When you have NumPy, install this package at the command line using
 
     pip install apexpy
 
-On Linux this will build apexpy from source, which requires a fortran compiler
-such as gfortran.
+This assumes that the same version of libgfortran is installed in the same location as when the pip wheel was built. If not, you may have trouble importing apexpy and you will have to build apexpy yourself using:
+
+pip install --global-option='build_ext' apexpy
+
+which requires both libgfortran and gfortran to be installed on your system.
 
 The package has been tested with the following setups (others might work, too):
 

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -390,9 +390,7 @@ def test_geo2apex_undefined_warning():
     A = Apex(date=2000, refh=10000)
     with warnings.catch_warnings(record=True) as w:
         ret = A.geo2apex(0, 0, 0)
-        A.geo2apex(0, 0, 0)
         assert ret[0] == -9999
-        assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
         assert 'set to -9999 where' in str(w[-1].message)
 
@@ -1193,8 +1191,6 @@ def test_basevectors_apex_invalid_scalar():
     with warnings.catch_warnings(record=True) as w:
         (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
          e3) = A.basevectors_apex(0, 0, 0)
-        A.basevectors_apex(0, 0, 0)
-        assert len(w) == 2
         assert issubclass(w[-1].category, UserWarning)
         assert 'set to -9999 where' in str(w[-1].message)
 

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -554,7 +554,7 @@ def test_apex2qd_apexheight_close():
 
 def test_apex2qd_apexheight_over():
     apex_out = Apex(date=2000, refh=300)
-    with pytest.raises(apex_outpexHeightError):
+    with pytest.raises(ApexHeightError):
         apex_out.apex2qd(0, 15, 301)
 
 

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -31,25 +31,25 @@ def test_init_defaults():
 
 
 def test_init_date_int():
-    A = Apex(date=2015)
-    assert A.year == 2015
+    apex_out = Apex(date=2015)
+    assert apex_out.year == 2015
 
 
 def test_init_date_float():
-    A = Apex(date=2015.5)
-    assert A.year == 2015.5
+    apex_out = Apex(date=2015.5)
+    assert apex_out.year == 2015.5
 
 
 def test_init_date():
     date = dt.date(2015, 1, 1)
-    A = Apex(date=date)
-    assert A.year == helpers.toYearFraction(date)
+    apex_out = Apex(date=date)
+    assert apex_out.year == helpers.toYearFraction(date)
 
 
 def test_init_datetime():
     datetime = dt.datetime(2015, 6, 1, 18, 23, 45)
-    A = Apex(date=datetime)
-    assert A.year == helpers.toYearFraction(datetime)
+    apex_out = Apex(date=datetime)
+    assert apex_out.year == helpers.toYearFraction(datetime)
 
 
 def test_init_datafile_IOError():
@@ -62,16 +62,17 @@ def test_init_datafile_IOError():
 ###============================================================================
 
 def test__geo2qd_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in [0, 30, 60, 89]:
         for lon in [-179, -90, 0, 90, 180]:
-            assert_allclose(A._geo2qd(lat, lon, 100),
+            assert_allclose(apex_out._geo2qd(lat, lon, 100),
                             fa.apxg2q(lat, lon, 100, 0)[:2])
 
 
 def test__geo2qd_array():
-    A = Apex(date=2000, refh=300)
-    lats, lons = A._geo2qd([[0, 30], [60, 90]], 15, [[100, 200], [300, 400]])
+    apex_out = Apex(date=2000, refh=300)
+    lats, lons = apex_out._geo2qd([[0, 30], [60, 90]], 15,
+                                  [[100, 200], [300, 400]])
     lat1, lon1 = fa.apxg2q(0, 15, 100, 0)[:2]
     lat2, lon2 = fa.apxg2q(30, 15, 200, 0)[:2]
     lat3, lon3 = fa.apxg2q(60, 15, 300, 0)[:2]
@@ -83,27 +84,31 @@ def test__geo2qd_array():
 
 
 def test__geo2qd_longitude():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A._geo2qd(60, 180, 100), fa.apxg2q(60, 180, 100, 0)[:2])
-    assert_allclose(A._geo2qd(60, -180, 100), fa.apxg2q(60, -180, 100, 0)[:2])
-    assert_allclose(A._geo2qd(60, -180, 100), A._geo2qd(60, 180, 100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out._geo2qd(60, 180, 100),
+                    fa.apxg2q(60, 180, 100, 0)[:2])
+    assert_allclose(apex_out._geo2qd(60, -180, 100),
+                    fa.apxg2q(60, -180, 100, 0)[:2])
+    assert_allclose(apex_out._geo2qd(60, -180, 100),
+                    apex_out._geo2qd(60, 180, 100))
     for i in range(-5, 5):
         for lat in [0, 30, 60, 90]:
-            assert_allclose(A._geo2qd(lat, 15+i*360, 100),
+            assert_allclose(apex_out._geo2qd(lat, 15+i*360, 100),
                             fa.apxg2q(lat, 15, 100, 0)[:2])
 
 
 def test__geo2apex_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in [0, 30, 60, 89]:
         for lon in [-179, -90, 0, 90, 180]:
-            assert_allclose(A._geo2apex(lat, lon, 100),
+            assert_allclose(apex_out._geo2apex(lat, lon, 100),
                             fa.apxg2all(lat, lon, 100, 300, 0)[2:4])
 
 
 def test__geo2apex_array():
-    A = Apex(date=2000, refh=300)
-    lats, lons = A._geo2apex([[0, 30], [60, 90]], 15, [[100, 200], [300, 400]])
+    apex_out = Apex(date=2000, refh=300)
+    lats, lons = apex_out._geo2apex([[0, 30], [60, 90]], 15,
+                                    [[100, 200], [300, 400]])
     lat1, lon1 = fa.apxg2all(0, 15, 100, 300, 0)[2:4]
     lat2, lon2 = fa.apxg2all(30, 15, 200, 300, 0)[2:4]
     lat3, lon3 = fa.apxg2all(60, 15, 300, 300, 0)[2:4]
@@ -115,31 +120,33 @@ def test__geo2apex_array():
 
 
 def test__geo2apex_longitude():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A._geo2apex(60, 180, 100),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out._geo2apex(60, 180, 100),
                     fa.apxg2all(60, 180, 100, 300, 0)[2:4])
-    assert_allclose(A._geo2apex(60, -180, 100),
+    assert_allclose(apex_out._geo2apex(60, -180, 100),
                     fa.apxg2all(60, -180, 100, 300, 0)[2:4])
-    assert_allclose(A._geo2apex(60, -180, 100), A._geo2apex(60, 180, 100))
+    assert_allclose(apex_out._geo2apex(60, -180, 100),
+                    apex_out._geo2apex(60, 180, 100))
     for i in range(-5, 5):
         for lat in [0, 30, 60, 90]:
-            assert_allclose(A._geo2apex(lat, 15+i*360, 100),
+            assert_allclose(apex_out._geo2apex(lat, 15+i*360, 100),
                             fa.apxg2all(lat, 15, 100, 300, 0)[2:4])
 
 
 def test__geo2apexall_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in [0, 30, 60, 89]:
         for lon in [-179, -90, 0, 90, 180]:
-            ret1 = A._geo2apexall(lat, lon, 100)
+            ret1 = apex_out._geo2apexall(lat, lon, 100)
             ret2 = fa.apxg2all(lat, lon, 100, 300, 1)
             for r1, r2 in zip(ret1, ret2):
                 assert_allclose(r1, r2)
 
 
 def test__geo2apexall_array():
-    A = Apex(date=2000, refh=300)
-    ret = A._geo2apexall([[0, 30], [60, 90]], 15, [[100, 200], [300, 400]])
+    apex_out = Apex(date=2000, refh=300)
+    ret = apex_out._geo2apexall([[0, 30], [60, 90]], 15,
+                                [[100, 200], [300, 400]])
     ret1 = fa.apxg2all(0, 15, 100, 300, 1)
     ret2 = fa.apxg2all(30, 15, 200, 300, 1)
     ret3 = fa.apxg2all(60, 15, 300, 300, 1)
@@ -159,17 +166,17 @@ def test__geo2apexall_array():
 
 
 def test__qd2geo_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in [0, 30, 60, 89]:
         for lon in [-179, -90, 0, 90, 180]:
             for prec in [-1, 1e-2, 1e-10]:
-                assert_allclose(A._qd2geo(lat, lon, 100, prec),
+                assert_allclose(apex_out._qd2geo(lat, lon, 100, prec),
                                 fa.apxq2g(lat, lon, 100, prec))
 
 
 def test__qd2geo_array():
-    A = Apex(date=2000, refh=300)
-    lats, lons, errs = A._qd2geo([[0, 30], [60, 90]], 15,
+    apex_out = Apex(date=2000, refh=300)
+    lats, lons, errs = apex_out._qd2geo([[0, 30], [60, 90]], 15,
                                  [[100, 200], [300, 400]], 1e-2)
     lat1, lon1, err1 = fa.apxq2g(0, 15, 100, 1e-2)
     lat2, lon2, err2 = fa.apxq2g(30, 15, 200, 1e-2)
@@ -184,30 +191,31 @@ def test__qd2geo_array():
 
 
 def test__qd2geo_longitude():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A._qd2geo(60, 180, 100, 1e-2),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out._qd2geo(60, 180, 100, 1e-2),
                     fa.apxq2g(60, 180, 100, 1e-2))
-    assert_allclose(A._qd2geo(60, -180, 100, 1e-2),
+    assert_allclose(apex_out._qd2geo(60, -180, 100, 1e-2),
                     fa.apxq2g(60, -180, 100, 1e-2))
-    assert_allclose(A._qd2geo(60, -180, 100, 1e-2),
-                    A._qd2geo(60, 180, 100, 1e-2))
+    assert_allclose(apex_out._qd2geo(60, -180, 100, 1e-2),
+                    apex_out._qd2geo(60, 180, 100, 1e-2))
     for i in range(-5, 5):
         for lat in [0, 30, 60, 90]:
-            assert_allclose(A._qd2geo(lat, 15+i*360, 100, 1e-2),
+            assert_allclose(apex_out._qd2geo(lat, 15+i*360, 100, 1e-2),
                             fa.apxq2g(lat, 15, 100, 1e-2))
 
 
 def test__basevec_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in [0, 30, 60, 89]:
         for lon in [-179, -90, 0, 90, 180]:
-            assert_allclose(A._basevec(lat, lon, 100),
+            assert_allclose(apex_out._basevec(lat, lon, 100),
                             fa.apxg2q(lat, lon, 100, 1)[2:4])
 
 
 def test__basevec_array():
-    A = Apex(date=2000, refh=300)
-    f1s, f2s = A._basevec([[0, 30], [60, 90]], 15, [[100, 200], [300, 400]])
+    apex_out = Apex(date=2000, refh=300)
+    f1s, f2s = apex_out._basevec([[0, 30], [60, 90]], 15,
+                                 [[100, 200], [300, 400]])
     f11, f21 = fa.apxg2q(0, 15, 100, 1)[2:4]
     f12, f22 = fa.apxg2q(30, 15, 200, 1)[2:4]
     f13, f23 = fa.apxg2q(60, 15, 300, 1)[2:4]
@@ -223,13 +231,16 @@ def test__basevec_array():
 
 
 def test__basevec_longitude():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A._basevec(60, 180, 100), fa.apxg2q(60, 180, 100, 1)[2:4])
-    assert_allclose(A._basevec(60, -180, 100), fa.apxg2q(60, -180, 100, 1)[2:4])
-    assert_allclose(A._basevec(60, -180, 100), A._basevec(60, 180, 100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out._basevec(60, 180, 100),
+                    fa.apxg2q(60, 180, 100, 1)[2:4])
+    assert_allclose(apex_out._basevec(60, -180, 100),
+                    fa.apxg2q(60, -180, 100, 1)[2:4])
+    assert_allclose(apex_out._basevec(60, -180, 100),
+                    apex_out._basevec(60, 180, 100))
     for i in range(-5, 5):
         for lat in [0, 30, 60, 90]:
-            assert_allclose(A._basevec(lat, 15+i*360, 100),
+            assert_allclose(apex_out._basevec(lat, 15+i*360, 100),
                             fa.apxg2q(lat, 15, 100, 1)[2:4])
 
 
@@ -239,118 +250,122 @@ def test__basevec_longitude():
 
 
 def test_convert_geo2apex():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'geo', 'apex', height=100),
-                    A.geo2apex(60, 15, 100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'geo', 'apex', height=100),
+                    apex_out.geo2apex(60, 15, 100))
 
 
 def test_convert_geo2qd():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'geo', 'qd', height=100),
-                    A.geo2qd(60, 15, 100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'geo', 'qd', height=100),
+                    apex_out.geo2qd(60, 15, 100))
 
 
 def test_convert_geo2mlt_nodate():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.convert(60, 15, 'geo', 'mlt')
+        apex_out.convert(60, 15, 'geo', 'mlt')
 
 
 def test_convert_geo2mlt():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'geo', 'mlt', height=100, ssheight=2e5,
-                              datetime=datetime)[1],
-                    A.mlon2mlt(A.geo2apex(60, 15, 100)[1], datetime,
-                               ssheight=2e5))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'geo', 'mlt', height=100,
+                                     ssheight=2e5, datetime=datetime)[1],
+                    apex_out.mlon2mlt(apex_out.geo2apex(60, 15, 100)[1],
+                                      datetime, ssheight=2e5))
 
 
 def test_convert_apex2geo():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'apex', 'geo', height=100,
-                              precision=1e-2), A.apex2geo(60, 15, 100,
-                                                          precision=1e-2)[:-1])
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'apex', 'geo', height=100,
+                                     precision=1e-2),
+                    apex_out.apex2geo(60, 15, 100, precision=1e-2)[:-1])
 
 
 def test_convert_apex2qd():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'apex', 'qd', height=100),
-                    A.apex2qd(60, 15, height=100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'apex', 'qd', height=100),
+                    apex_out.apex2qd(60, 15, height=100))
 
 
 def test_convert_apex2mlt():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'apex', 'mlt', height=100,
-                              datetime=datetime, ssheight=2e5)[1],
-                    A.mlon2mlt(15, datetime, ssheight=2e5))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'apex', 'mlt', height=100,
+                                     datetime=datetime, ssheight=2e5)[1],
+                    apex_out.mlon2mlt(15, datetime, ssheight=2e5))
 
 
 def test_convert_qd2geo():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'qd', 'geo', height=100, precision=1e-2),
-                    A.qd2geo(60, 15, 100, precision=1e-2)[:-1])
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'qd', 'geo', height=100,
+                                     precision=1e-2),
+                    apex_out.qd2geo(60, 15, 100, precision=1e-2)[:-1])
 
 
 def test_convert_qd2apex():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'qd', 'apex', height=100),
-                    A.qd2apex(60, 15, height=100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'qd', 'apex', height=100),
+                    apex_out.qd2apex(60, 15, height=100))
 
 
 def test_convert_qd2mlt():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'qd', 'mlt', height=100,
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'qd', 'mlt', height=100,
                               datetime=datetime, ssheight=2e5)[1],
-                    A.mlon2mlt(15, datetime, ssheight=2e5))
+                    apex_out.mlon2mlt(15, datetime, ssheight=2e5))
 
 
 def test_convert_mlt2geo():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'mlt', 'geo', height=100,
-                              datetime=datetime, precision=1e-2, ssheight=2e5),
-                    A.apex2geo(60, A.mlt2mlon(15, datetime, ssheight=2e5), 100,
-                               precision=1e-2)[:-1])
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'mlt', 'geo', height=100,
+                                     datetime=datetime, precision=1e-2,
+                                     ssheight=2e5),
+                    apex_out.apex2geo(60, apex_out.mlt2mlon(15, datetime,
+                                                            ssheight=2e5), 100,
+                                      precision=1e-2)[:-1])
 
 
 def test_convert_mlt2apex():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'mlt', 'apex', height=100,
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'mlt', 'apex', height=100,
                               datetime=datetime, ssheight=2e5),
-                    (60, A.mlt2mlon(15, datetime, ssheight=2e5)))
+                    (60, apex_out.mlt2mlon(15, datetime, ssheight=2e5)))
 
 
 def test_convert_mlt2qd():
     datetime = dt.datetime(2000, 3, 9, 14, 25, 58)
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.convert(60, 15, 'mlt', 'qd', height=100,
-                              datetime=datetime, ssheight=2e5),
-                    A.apex2qd(60, A.mlt2mlon(15, datetime, ssheight=2e5),
-                              height=100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.convert(60, 15, 'mlt', 'qd', height=100,
+                                     datetime=datetime, ssheight=2e5),
+                    apex_out.apex2qd(60, apex_out.mlt2mlon(15, datetime,
+                                                           ssheight=2e5),
+                                     height=100))
 
 
 def test_convert_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.convert(91, 0, 'geo', 'geo')
+        apex_out.convert(91, 0, 'geo', 'geo')
     with pytest.raises(ValueError):
-        A.convert(-91, 0, 'geo', 'geo')
-    A.convert(90, 0, 'geo', 'geo')
-    A.convert(-90, 0, 'geo', 'geo')
+        apex_out.convert(-91, 0, 'geo', 'geo')
+    apex_out.convert(90, 0, 'geo', 'geo')
+    apex_out.convert(-90, 0, 'geo', 'geo')
 
-    assert_allclose(A.convert(90+1e-5, 0, 'geo', 'apex'),
-                    A.convert(90, 0, 'geo', 'apex'), rtol=0, atol=1e-8)
+    assert_allclose(apex_out.convert(90+1e-5, 0, 'geo', 'apex'),
+                    apex_out.convert(90, 0, 'geo', 'apex'), rtol=0, atol=1e-8)
 
 
 def test_convert_invalid_transformation():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(NotImplementedError):
-        A.convert(0, 0, 'foobar', 'geo')
+        apex_out.convert(0, 0, 'foobar', 'geo')
     with pytest.raises(NotImplementedError):
-        A.convert(0, 0, 'geo', 'foobar')
+        apex_out.convert(0, 0, 'geo', 'foobar')
 
 
 ###============================================================================
@@ -359,37 +374,37 @@ def test_convert_invalid_transformation():
 
 
 def test_geo2apex():
-    A = Apex(date=2000, refh=300)
-    lat, lon = A.geo2apex(60, 15, 100)
-    assert_allclose((lat, lon), A._geo2apex(60, 15, 100))
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon = apex_out.geo2apex(60, 15, 100)
+    assert_allclose((lat, lon), apex_out._geo2apex(60, 15, 100))
     assert type(lat) != np.ndarray
     assert type(lon) != np.ndarray
 
 
 def test_geo2apex_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.geo2apex([60, 60], 15, 100)[0].shape == (2,)
-    assert A.geo2apex(60, [15, 15], 100)[0].shape == (2,)
-    assert A.geo2apex(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.geo2apex([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.geo2apex(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.geo2apex(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_geo2apex_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.geo2apex(91, 0, 0)
+        apex_out.geo2apex(91, 0, 0)
     with pytest.raises(ValueError):
-        A.geo2apex(-91, 0, 0)
-    A.geo2apex(90, 0, 0)
-    A.geo2apex(-90, 0, 0)
+        apex_out.geo2apex(-91, 0, 0)
+    apex_out.geo2apex(90, 0, 0)
+    apex_out.geo2apex(-90, 0, 0)
 
-    assert_allclose(A.geo2apex(90+1e-5, 0, 0), A.geo2apex(90, 0, 0), rtol=0,
-                    atol=1e-8)
+    assert_allclose(apex_out.geo2apex(90+1e-5, 0, 0),
+                    apex_out.geo2apex(90, 0, 0), rtol=0, atol=1e-8)
 
 
 def test_geo2apex_undefined_warning():
-    A = Apex(date=2000, refh=10000)
+    apex_out = Apex(date=2000, refh=10000)
     with warnings.catch_warnings(record=True) as w:
-        ret = A.geo2apex(0, 0, 0)
+        ret = apex_out.geo2apex(0, 0, 0)
         assert ret[0] == -9999
         assert issubclass(w[-1].category, UserWarning)
         assert 'set to -9999 where' in str(w[-1].message)
@@ -401,10 +416,10 @@ def test_geo2apex_undefined_warning():
 
 
 def test_apex2geo():
-    A = Apex(date=2000, refh=300)
-    lat, lon, error = A.apex2geo(60, 15, 100, precision=1e-2)
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon, error = apex_out.apex2geo(60, 15, 100, precision=1e-2)
     assert_allclose((lat, lon, error),
-                    A.qd2geo(*A.apex2qd(60, 15, 100), height=100,
+                    apex_out.qd2geo(*apex_out.apex2qd(60, 15, 100), height=100,
                              precision=1e-2))
     assert type(lat) != np.ndarray
     assert type(lon) != np.ndarray
@@ -412,23 +427,23 @@ def test_apex2geo():
 
 
 def test_apex2geo_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.apex2geo([60, 60], 15, 100)[0].shape == (2,)
-    assert A.apex2geo(60, [15, 15], 100)[0].shape == (2,)
-    assert A.apex2geo(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.apex2geo([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.apex2geo(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.apex2geo(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_apex2geo_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.apex2geo(91, 0, 0, 1e-2)
+        apex_out.apex2geo(91, 0, 0, 1e-2)
     with pytest.raises(ValueError):
-        A.apex2geo(-91, 0, 0, 1e-2)
-    A.apex2geo(90, 0, 0, 1e-2)
-    A.apex2geo(-90, 0, 0, 1e-2)
+        apex_out.apex2geo(-91, 0, 0, 1e-2)
+    apex_out.apex2geo(90, 0, 0, 1e-2)
+    apex_out.apex2geo(-90, 0, 0, 1e-2)
 
-    assert_allclose(A.apex2geo(90+1e-5, 0, 0, 1e-2), A.apex2geo(90, 0, 0, 1e-2),
-                    rtol=0, atol=1e-8)
+    assert_allclose(apex_out.apex2geo(90+1e-5, 0, 0, 1e-2),
+                    apex_out.apex2geo(90, 0, 0, 1e-2), rtol=0, atol=1e-8)
 
 
 ###============================================================================
@@ -437,31 +452,31 @@ def test_apex2geo_invalid_lat():
 
 
 def test_geo2qd():
-    A = Apex(date=2000, refh=300)
-    lat, lon = A.geo2qd(60, 15, 100)
-    assert_allclose((lat, lon), A._geo2qd(60, 15, 100))
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon = apex_out.geo2qd(60, 15, 100)
+    assert_allclose((lat, lon), apex_out._geo2qd(60, 15, 100))
     assert type(lat) != np.ndarray
     assert type(lon) != np.ndarray
 
 
 def test_geo2qd_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.geo2qd([60, 60], 15, 100)[0].shape == (2,)
-    assert A.geo2qd(60, [15, 15], 100)[0].shape == (2,)
-    assert A.geo2qd(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.geo2qd([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.geo2qd(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.geo2qd(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_geo2qd_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.geo2qd(91, 0, 0)
+        apex_out.geo2qd(91, 0, 0)
     with pytest.raises(ValueError):
-        A.geo2qd(-91, 0, 0)
-    A.geo2qd(90, 0, 0)
-    A.geo2qd(-90, 0, 0)
+        apex_out.geo2qd(-91, 0, 0)
+    apex_out.geo2qd(90, 0, 0)
+    apex_out.geo2qd(-90, 0, 0)
 
-    assert_allclose(A.geo2qd(90+1e-5, 0, 0), A.geo2qd(90, 0, 0), rtol=0,
-                    atol=1e-8)
+    assert_allclose(apex_out.geo2qd(90+1e-5, 0, 0), apex_out.geo2qd(90, 0, 0),
+                    rtol=0, atol=1e-8)
 
 
 ###============================================================================
@@ -470,32 +485,32 @@ def test_geo2qd_invalid_lat():
 
 
 def test_qd2geo():
-    A = Apex(date=2000, refh=300)
-    lat, lon, error = A.qd2geo(60, 15, 100, precision=1e-2)
-    assert_allclose((lat, lon, error), A._qd2geo(60, 15, 100, 1e-2))
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon, error = apex_out.qd2geo(60, 15, 100, precision=1e-2)
+    assert_allclose((lat, lon, error), apex_out._qd2geo(60, 15, 100, 1e-2))
     assert type(lat) != np.ndarray
     assert type(lon) != np.ndarray
     assert type(error) != np.ndarray
 
 
 def test_qd2geo_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.qd2geo([60, 60], 15, 100)[0].shape == (2,)
-    assert A.qd2geo(60, [15, 15], 100)[0].shape == (2,)
-    assert A.qd2geo(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.qd2geo([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.qd2geo(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.qd2geo(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_qd2geo_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.qd2geo(91, 0, 0, precision=1e-2)
+        apex_out.qd2geo(91, 0, 0, precision=1e-2)
     with pytest.raises(ValueError):
-        A.qd2geo(-91, 0, 0, precision=1e-2)
-    A.qd2geo(90, 0, 0, precision=1e-2)
-    A.qd2geo(-90, 0, 0, precision=1e-2)
+        apex_out.qd2geo(-91, 0, 0, precision=1e-2)
+    apex_out.qd2geo(90, 0, 0, precision=1e-2)
+    apex_out.qd2geo(-90, 0, 0, precision=1e-2)
 
-    assert_allclose(A.qd2geo(90+1e-5, 0, 0, 1e-2), A.qd2geo(90, 0, 0, 1e-2),
-                    rtol=0, atol=1e-8)
+    assert_allclose(apex_out.qd2geo(90+1e-5, 0, 0, 1e-2),
+                    apex_out.qd2geo(90, 0, 0, 1e-2), rtol=0, atol=1e-8)
 
 
 ###============================================================================
@@ -504,8 +519,8 @@ def test_qd2geo_invalid_lat():
 
 
 def test_apex2qd():
-    A = Apex(date=2000, refh=300)
-    lat, lon = A.apex2qd(60, 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon = apex_out.apex2qd(60, 15, 100)
     assert_allclose((lat, lon),
                     [60.498401, 15])
     assert type(lat) != np.ndarray
@@ -513,34 +528,34 @@ def test_apex2qd():
 
 
 def test_apex2qd_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.apex2qd([60, 60], 15, 100)[0].shape == (2,)
-    assert A.apex2qd(60, [15, 15], 100)[0].shape == (2,)
-    assert A.apex2qd(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.apex2qd([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.apex2qd(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.apex2qd(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_apex2qd_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.apex2qd(91, 0, 0)
+        apex_out.apex2qd(91, 0, 0)
     with pytest.raises(ValueError):
-        A.apex2qd(-91, 0, 0)
-    A.apex2qd(90, 0, 0)
-    A.apex2qd(-90, 0, 0)
+        apex_out.apex2qd(-91, 0, 0)
+    apex_out.apex2qd(90, 0, 0)
+    apex_out.apex2qd(-90, 0, 0)
 
-    assert_allclose(A.apex2qd(90+1e-5, 0, 0), A.apex2qd(90, 0, 0), rtol=0,
-                    atol=1e-8)
+    assert_allclose(apex_out.apex2qd(90+1e-5, 0, 0), apex_out.apex2qd(90, 0, 0),
+                    rtol=0, atol=1e-8)
 
 
 def test_apex2qd_apexheight_close():
-    A = Apex(date=2000, refh=300)
-    A.apex2qd(0, 15, 300+1e-6)
+    apex_out = Apex(date=2000, refh=300)
+    apex_out.apex2qd(0, 15, 300+1e-6)
 
 
 def test_apex2qd_apexheight_over():
-    A = Apex(date=2000, refh=300)
-    with pytest.raises(ApexHeightError):
-        A.apex2qd(0, 15, 301)
+    apex_out = Apex(date=2000, refh=300)
+    with pytest.raises(apex_outpexHeightError):
+        apex_out.apex2qd(0, 15, 301)
 
 
 ###============================================================================
@@ -549,8 +564,8 @@ def test_apex2qd_apexheight_over():
 
 
 def test_qd2apex():
-    A = Apex(date=2000, refh=300)
-    lat, lon = A.qd2apex(60, 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    lat, lon = apex_out.qd2apex(60, 15, 100)
     assert_allclose((lat, lon),
                     [59.491381, 15])
     assert type(lat) != np.ndarray
@@ -558,34 +573,35 @@ def test_qd2apex():
 
 
 def test_qd2apex_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert A.qd2apex([60, 60], 15, 100)[0].shape == (2,)
-    assert A.qd2apex(60, [15, 15], 100)[0].shape == (2,)
-    assert A.qd2apex(60, 15, [100, 100])[0].shape == (2,)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.qd2apex([60, 60], 15, 100)[0].shape == (2,)
+    assert apex_out.qd2apex(60, [15, 15], 100)[0].shape == (2,)
+    assert apex_out.qd2apex(60, 15, [100, 100])[0].shape == (2,)
 
 
 def test_qd2apex_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.qd2apex(91, 0, 0)
+        apex_out.qd2apex(91, 0, 0)
     with pytest.raises(ValueError):
-        A.qd2apex(-91, 0, 0)
-    A.qd2apex(90, 0, 0)
-    A.qd2apex(-90, 0, 0)
+        apex_out.qd2apex(-91, 0, 0)
+    apex_out.qd2apex(90, 0, 0)
+    apex_out.qd2apex(-90, 0, 0)
 
-    assert_allclose(A.qd2apex(90+1e-5, 0, 0), A.qd2apex(90, 0, 0), rtol=0,
-                    atol=1e-8)
+    assert_allclose(apex_out.qd2apex(90+1e-5, 0, 0), apex_out.qd2apex(90, 0, 0),
+                    rtol=0, atol=1e-8)
 
 
 def test_qd2apex_apexheight_close():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.qd2apex(0, 15, 300-1e-5), A.qd2apex(0, 15, 300))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.qd2apex(0, 15, 300-1e-5),
+                    apex_out.qd2apex(0, 15, 300))
 
 
 def test_qd2apex_apexheight_over():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ApexHeightError):
-        A.qd2apex(0, 15, 299)
+        apex_out.qd2apex(0, 15, 299)
 
 
 ###============================================================================
@@ -594,48 +610,52 @@ def test_qd2apex_apexheight_over():
 
 
 def test_mlon2mlt_scalar():
-    A = Apex(date=2000, refh=300)
-    mlon = A.mlon2mlt(0, dt.datetime(2000, 2, 3, 4, 5, 6))
+    apex_out = Apex(date=2000, refh=300)
+    mlon = apex_out.mlon2mlt(0, dt.datetime(2000, 2, 3, 4, 5, 6))
     assert_allclose(mlon, 23.019629923502603)
     assert type(mlon) != np.ndarray
 
 
 def test_mlon2mlt_ssheight():
-    A = Apex(date=2000, refh=300)
-    mlt = A.mlon2mlt(0, dt.datetime(2000, 2, 3, 4, 5, 6), ssheight=50*2000)
+    apex_out = Apex(date=2000, refh=300)
+    mlt = apex_out.mlon2mlt(0, dt.datetime(2000, 2, 3, 4, 5, 6),
+                            ssheight=50*2000)
     assert_allclose(mlt, 23.026712036132814)
 
 
 def test_mlon2mlt_1Darray():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlon2mlt([0, 180], dt.datetime(2000, 2, 3, 4, 5, 6)),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlon2mlt([0, 180],
+                                      dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [23.019261, 11.019261], rtol=1e-4)
 
 
 def test_mlon2mlt_2Darray():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlon2mlt([[0, 180], [0, 180]],
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlon2mlt([[0, 180], [0, 180]],
                                dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [[23.019261, 11.019261], [23.019261, 11.019261]], rtol=1e-4)
 
 
 def test_mlon2mlt_diffdates():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     dtime1 = dt.datetime(2000, 2, 3, 4, 5, 6)
     dtime2 = dt.datetime(2000, 2, 3, 5, 5, 6)
-    assert A.mlon2mlt(0, dtime1) != A.mlon2mlt(0, dtime2)
+    assert apex_out.mlon2mlt(0, dtime1) != apex_out.mlon2mlt(0, dtime2)
 
 
 def test_mlon2mlt_offset():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     date = dt.datetime(2000, 2, 3, 4, 5, 6)
-    assert_allclose(A.mlon2mlt(0, date), A.mlon2mlt(-15, date) + 1)
-    assert_allclose(A.mlon2mlt(0, date), A.mlon2mlt(-10*15, date) + 10)
+    assert_allclose(apex_out.mlon2mlt(0, date),
+                    apex_out.mlon2mlt(-15, date) + 1)
+    assert_allclose(apex_out.mlon2mlt(0, date),
+                    apex_out.mlon2mlt(-10*15, date) + 10)
 
 
 def test_mlon2mlt_range():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlon2mlt(range(0, 361, 30),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlon2mlt(range(0, 361, 30),
                                dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [23.01963, 1.01963, 3.01963, 5.01963, 7.01963,
                      9.01963, 11.01963, 13.01963, 15.01963, 17.01963,
@@ -649,49 +669,52 @@ def test_mlon2mlt_range():
 
 
 def test_mlt2mlon_scalar():
-    A = Apex(date=2000, refh=300)
-    mlt = A.mlt2mlon(0, dt.datetime(2000, 2, 3, 4, 5, 6))
+    apex_out = Apex(date=2000, refh=300)
+    mlt = apex_out.mlt2mlon(0, dt.datetime(2000, 2, 3, 4, 5, 6))
     assert_allclose(mlt, 14.705551147460938)
     assert type(mlt) != np.ndarray
 
 
 def test_mlt2mlon_ssheight():
-    A = Apex(date=2000, refh=300)
-    mlt = A.mlt2mlon(0, dt.datetime(2000, 2, 3, 4, 5, 6), ssheight=50*2000)
+    apex_out = Apex(date=2000, refh=300)
+    mlt = apex_out.mlt2mlon(0, dt.datetime(2000, 2, 3, 4, 5, 6),
+                            ssheight=50*2000)
     assert_allclose(mlt, 14.599319458007812)
 
 
 def test_mlt2mlon_1Darray():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlt2mlon([0, 12], dt.datetime(2000, 2, 3, 4, 5, 6)),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlt2mlon([0, 12],
+                                      dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [14.705551, 194.705551], rtol=1e-4)
 
 
 def test_mlt2mlon_2Darray():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlt2mlon([[0, 12], [0, 12]],
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlt2mlon([[0, 12], [0, 12]],
                                dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [[14.705551, 194.705551], [14.705551, 194.705551]],
                     rtol=1e-4)
 
 
 def test_mlt2mlon_diffdates():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     dtime1 = dt.datetime(2000, 2, 3, 4, 5, 6)
     dtime2 = dt.datetime(2000, 2, 3, 5, 5, 6)
-    assert A.mlt2mlon(0, dtime1) != A.mlt2mlon(0, dtime2)
+    assert apex_out.mlt2mlon(0, dtime1) != apex_out.mlt2mlon(0, dtime2)
 
 
 def test_mlt2mlon_offset():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     date = dt.datetime(2000, 2, 3, 4, 5, 6)
-    assert_allclose(A.mlt2mlon(0, date), A.mlt2mlon(1, date) - 15)
-    assert_allclose(A.mlt2mlon(0, date), A.mlt2mlon(10, date) - 150)
+    assert_allclose(apex_out.mlt2mlon(0, date), apex_out.mlt2mlon(1, date) - 15)
+    assert_allclose(apex_out.mlt2mlon(0, date),
+                    apex_out.mlt2mlon(10, date) - 150)
 
 
 def test_mlt2mlon_range():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.mlt2mlon(range(0, 25, 2),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.mlt2mlon(range(0, 25, 2),
                                dt.datetime(2000, 2, 3, 4, 5, 6)),
                     [14.705551, 44.705551, 74.705551, 104.705551, 134.705551,
                      164.705551, 194.705551, 224.705551, 254.705551, 284.705551,
@@ -705,23 +728,23 @@ def test_mlt2mlon_range():
 
 
 def test_mlon2mlt2mlon():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     date = dt.datetime(2000, 2, 3, 4, 5, 6)
-    assert_allclose(A.mlon2mlt(A.mlt2mlon(0, date), date), 0)
-    assert_allclose(A.mlon2mlt(A.mlt2mlon(6, date), date), 6)
-    assert_allclose(A.mlon2mlt(A.mlt2mlon(12, date), date), 12)
-    assert_allclose(A.mlon2mlt(A.mlt2mlon(18, date), date), 18)
-    assert_allclose(A.mlon2mlt(A.mlt2mlon(24, date), date), 0)
+    assert_allclose(apex_out.mlon2mlt(apex_out.mlt2mlon(0, date), date), 0)
+    assert_allclose(apex_out.mlon2mlt(apex_out.mlt2mlon(6, date), date), 6)
+    assert_allclose(apex_out.mlon2mlt(apex_out.mlt2mlon(12, date), date), 12)
+    assert_allclose(apex_out.mlon2mlt(apex_out.mlt2mlon(18, date), date), 18)
+    assert_allclose(apex_out.mlon2mlt(apex_out.mlt2mlon(24, date), date), 0)
 
 
 def test_mlt2mlon2mlt():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     date = dt.datetime(2000, 2, 3, 4, 5, 6)
-    assert_allclose(A.mlt2mlon(A.mlon2mlt(0, date), date), 0)
-    assert_allclose(A.mlt2mlon(A.mlon2mlt(90, date), date), 90)
-    assert_allclose(A.mlt2mlon(A.mlon2mlt(180, date), date), 180)
-    assert_allclose(A.mlt2mlon(A.mlon2mlt(270, date), date), 270)
-    assert_allclose(A.mlt2mlon(A.mlon2mlt(360, date), date), 0)
+    assert_allclose(apex_out.mlt2mlon(apex_out.mlon2mlt(0, date), date), 0)
+    assert_allclose(apex_out.mlt2mlon(apex_out.mlon2mlt(90, date), date), 90)
+    assert_allclose(apex_out.mlt2mlon(apex_out.mlon2mlt(180, date), date), 180)
+    assert_allclose(apex_out.mlt2mlon(apex_out.mlon2mlt(270, date), date), 270)
+    assert_allclose(apex_out.mlt2mlon(apex_out.mlon2mlt(360, date), date), 0)
 
 
 ###============================================================================
@@ -730,50 +753,50 @@ def test_mlt2mlon2mlt():
 
 
 def test_map_to_height():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.map_to_height(60, 15, 100, 10000, conjugate=False,
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.map_to_height(60, 15, 100, 10000, conjugate=False,
                                     precision=1e-10),
                     (31.841459274291992, 17.916629791259766, 0))
-    assert_allclose(A.map_to_height(30, 170, 100, 500, conjugate=False,
+    assert_allclose(apex_out.map_to_height(30, 170, 100, 500, conjugate=False,
                                     precision=1e-2),
                     (25.727252960205078, 169.60546875, 0.00017655163537710905))
 
 
 def test_map_to_height_same_height():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.map_to_height(60, 15, 100, 100, conjugate=False,
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.map_to_height(60, 15, 100, 100, conjugate=False,
                                     precision=1e-10),
                     (60, 15, 3.4150946248701075e-6), rtol=1e-5)
 
 
 def test_map_to_height_conjugate():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.map_to_height(60, 15, 100, 10000, conjugate=True,
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.map_to_height(60, 15, 100, 10000, conjugate=True,
                                     precision=1e-10),
                     (-25.424892425537109, 27.310417175292969,
                      1.2074182222931995e-6))
-    assert_allclose(A.map_to_height(30, 170, 100, 500, conjugate=True,
+    assert_allclose(apex_out.map_to_height(30, 170, 100, 500, conjugate=True,
                                     precision=1e-2),
                     (-13.76642894744873, 164.24259948730469,
                      0.00056820799363777041))
 
 
 def test_map_to_height_vectorization():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.map_to_height([60, 60], 15, 100, 100),
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.map_to_height([60, 60], 15, 100, 100),
                     ([60]*2, [15]*2, [3.4150946248701075e-6]*2), rtol=1e-5)
-    assert_allclose(A.map_to_height(60, [15, 15], 100, 100),
+    assert_allclose(apex_out.map_to_height(60, [15, 15], 100, 100),
                     ([60]*2, [15]*2, [3.4150946248701075e-6]*2), rtol=1e-5)
-    assert_allclose(A.map_to_height(60, 15, [100, 100], 100),
+    assert_allclose(apex_out.map_to_height(60, 15, [100, 100], 100),
                     ([60]*2, [15]*2, [3.4150946248701075e-6]*2), rtol=1e-5)
-    assert_allclose(A.map_to_height(60, 15, 100, [100, 100]),
+    assert_allclose(apex_out.map_to_height(60, 15, 100, [100, 100]),
                     ([60]*2, [15]*2, [3.4150946248701075e-6]*2), rtol=1e-5)
 
 
 def test_map_to_height_ApexHeightError():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ApexHeightError):
-        A.map_to_height(0, 15, 100, 10000)
+        apex_out.map_to_height(0, 15, 100, 10000)
 
 
 ###============================================================================
@@ -782,7 +805,7 @@ def test_map_to_height_ApexHeightError():
 
 
 def test_map_E_to_height():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     out_60_15_100_500 = [0.7115211, 2.3562392, 0.57259707]
     out_60_15_100_500_234 = [1.560284, 3.439154, 0.782339]
     out_60_15_100_1000 = [0.677964, 2.089811, 0.558601]
@@ -791,45 +814,45 @@ def test_map_E_to_height():
     out_70_15_100_500 = [0.727605, 2.180817, 0.291414]
 
     # scalar
-    assert_allclose(A.map_E_to_height(60, 15, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_E_to_height(60, 15, 100, 500, [1, 2, 3]),
                     out_60_15_100_500, rtol=1e-5)
-    assert_allclose(A.map_E_to_height(60, 15, 100, 500, [2, 3, 4]),
+    assert_allclose(apex_out.map_E_to_height(60, 15, 100, 500, [2, 3, 4]),
                     out_60_15_100_500_234, rtol=1e-5)
-    assert_allclose(A.map_E_to_height(60, 15, 100, 1000, [1, 2, 3]),
+    assert_allclose(apex_out.map_E_to_height(60, 15, 100, 1000, [1, 2, 3]),
                     out_60_15_100_1000, rtol=1e-5)
-    assert_allclose(A.map_E_to_height(60, 15, 200, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_E_to_height(60, 15, 200, 500, [1, 2, 3]),
                     out_60_15_200_500, rtol=1e-5)
-    assert_allclose(A.map_E_to_height(60, 30, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_E_to_height(60, 30, 100, 500, [1, 2, 3]),
                     out_60_30_100_500, rtol=1e-5)
-    assert_allclose(A.map_E_to_height(70, 15, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_E_to_height(70, 15, 100, 500, [1, 2, 3]),
                     out_70_15_100_500, rtol=1e-5)
 
     # vectorize lat
-    assert_allclose(A.map_E_to_height([60, 70], 15, 100, 500,
+    assert_allclose(apex_out.map_E_to_height([60, 70], 15, 100, 500,
                                       np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_70_15_100_500]).T,
                     rtol=1e-5)
 
     # vectorize lon
-    assert_allclose(A.map_E_to_height(60, [15, 30], 100, 500,
+    assert_allclose(apex_out.map_E_to_height(60, [15, 30], 100, 500,
                                       np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_30_100_500]).T,
                     rtol=1e-5)
 
     # vectorize height
-    assert_allclose(A.map_E_to_height(60, 15, [100, 200], 500,
+    assert_allclose(apex_out.map_E_to_height(60, 15, [100, 200], 500,
                                       np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_15_200_500]).T,
                     rtol=1e-5)
 
     # vectorize newheight
-    assert_allclose(A.map_E_to_height(60, 15, 100, [500, 1000],
+    assert_allclose(apex_out.map_E_to_height(60, 15, 100, [500, 1000],
                                       np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_15_100_1000]).T,
                     rtol=1e-5)
 
     # vectorize E
-    assert_allclose(A.map_E_to_height(60, 15, 100, 500,
+    assert_allclose(apex_out.map_E_to_height(60, 15, 100, 500,
                                       np.array([[1, 2, 3], [2, 3, 4]]).T),
                     np.array([out_60_15_100_500, out_60_15_100_500_234]).T,
                     rtol=1e-5)
@@ -841,7 +864,7 @@ def test_map_E_to_height():
 
 
 def test_map_V_to_height():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     out_60_15_100_500 = [0.819719, 2.845114, 0.695437]
     out_60_15_100_500_234 = [1.830277, 4.14345, 0.947624]
     out_60_15_100_1000 = [0.924577, 3.149964, 0.851343]
@@ -850,46 +873,47 @@ def test_map_V_to_height():
     out_70_15_100_500 = [0.846819, 2.592572, 0.347919]
 
     # scalar
-    assert_allclose(A.map_V_to_height(60, 15, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 100, 500, [1, 2, 3]),
                     out_60_15_100_500, rtol=1e-5)
-    assert_allclose(A.map_V_to_height(60, 15, 100, 500, [2, 3, 4]),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 100, 500, [2, 3, 4]),
                     out_60_15_100_500_234, rtol=1e-5)
-    assert_allclose(A.map_V_to_height(60, 15, 100, 1000, [1, 2, 3]),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 100, 1000, [1, 2, 3]),
                     out_60_15_100_1000, rtol=1e-5)
-    assert_allclose(A.map_V_to_height(60, 15, 200, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 200, 500, [1, 2, 3]),
                     out_60_15_200_500, rtol=1e-5)
-    assert_allclose(A.map_V_to_height(60, 30, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_V_to_height(60, 30, 100, 500, [1, 2, 3]),
                     out_60_30_100_500, rtol=1e-5)
-    assert_allclose(A.map_V_to_height(70, 15, 100, 500, [1, 2, 3]),
+    assert_allclose(apex_out.map_V_to_height(70, 15, 100, 500, [1, 2, 3]),
                     out_70_15_100_500, rtol=1e-5)
 
     # vectorize lat
-    assert_allclose(A.map_V_to_height([60, 70], 15, 100, 500,
-                                      np.array([[1, 2, 3]]*2).T),
+    assert_allclose(apex_out.map_V_to_height([60, 70], 15, 100, 500,
+                                             np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_70_15_100_500]).T,
                     rtol=1e-5)
 
     # vectorize lon
-    assert_allclose(A.map_V_to_height(60, [15, 30], 100, 500,
-                                      np.array([[1, 2, 3]]*2).T),
+    assert_allclose(apex_out.map_V_to_height(60, [15, 30], 100, 500,
+                                             np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_30_100_500]).T,
                     rtol=1e-5)
 
     # vectorize height
-    assert_allclose(A.map_V_to_height(60, 15, [100, 200], 500,
-                                      np.array([[1, 2, 3]]*2).T),
+    assert_allclose(apex_out.map_V_to_height(60, 15, [100, 200], 500,
+                                             np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_15_200_500]).T,
                     rtol=1e-5)
 
     # vectorize newheight
-    assert_allclose(A.map_V_to_height(60, 15, 100, [500, 1000],
-                                      np.array([[1, 2, 3]]*2).T),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 100, [500, 1000],
+                                             np.array([[1, 2, 3]]*2).T),
                     np.array([out_60_15_100_500, out_60_15_100_1000]).T,
                     rtol=1e-5)
 
     # vectorize E
-    assert_allclose(A.map_V_to_height(60, 15, 100, 500,
-                                      np.array([[1, 2, 3], [2, 3, 4]]).T),
+    assert_allclose(apex_out.map_V_to_height(60, 15, 100, 500,
+                                             np.array([[1, 2, 3],
+                                                       [2, 3, 4]]).T),
                     np.array([out_60_15_100_500, out_60_15_100_500_234]).T,
                     rtol=1e-5)
 
@@ -902,43 +926,44 @@ def test_map_V_to_height():
 # test coords
 
 def test_basevectors_qd_scalar_geo():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.basevectors_qd(60, 15, 100, coords='geo'),
-                    A._basevec(60, 15, 100))
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.basevectors_qd(60, 15, 100, coords='geo'),
+                    apex_out._basevec(60, 15, 100))
 
 
 def test_basevectors_qd_scalar_apex():
-    A = Apex(date=2000, refh=300)
-    glat, glon, _ = A.apex2geo(60, 15, 100, precision=1e-2)
-    assert_allclose(A.basevectors_qd(60, 15, 100, coords='apex',
-                                     precision=1e-2),
-                    A._basevec(glat, glon, 100))
+    apex_out = Apex(date=2000, refh=300)
+    glat, glon, _ = apex_out.apex2geo(60, 15, 100, precision=1e-2)
+    assert_allclose(apex_out.basevectors_qd(60, 15, 100, coords='apex',
+                                            precision=1e-2),
+                    apex_out._basevec(glat, glon, 100))
 
 
 def test_basevectors_qd_scalar_qd():
-    A = Apex(date=2000, refh=300)
-    glat, glon, _ = A.qd2geo(60, 15, 100, precision=1e-2)
-    assert_allclose(A.basevectors_qd(60, 15, 100, coords='qd', precision=1e-2),
-                    A._basevec(glat, glon, 100))
+    apex_out = Apex(date=2000, refh=300)
+    glat, glon, _ = apex_out.qd2geo(60, 15, 100, precision=1e-2)
+    assert_allclose(apex_out.basevectors_qd(60, 15, 100, coords='qd',
+                                            precision=1e-2),
+                    apex_out._basevec(glat, glon, 100))
 
 # test shapes and vectorization of arguments
 
 def test_basevectors_qd_scalar_shape():
-    A = Apex(date=2000, refh=300)
-    ret = A.basevectors_qd(60, 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    ret = apex_out.basevectors_qd(60, 15, 100)
     for r in ret:
         assert r.shape == (2,)
 
 
 def test_basevectors_qd_vectorization():
-    A = Apex(date=2000, refh=300)
-    ret = A.basevectors_qd([60, 60, 60, 60], 15, 100, coords='geo')
+    apex_out = Apex(date=2000, refh=300)
+    ret = apex_out.basevectors_qd([60, 60, 60, 60], 15, 100, coords='geo')
     for r in ret:
         assert r.shape == (2, 4)
-    ret = A.basevectors_qd(60, [15, 15, 15, 15], 100, coords='geo')
+    ret = apex_out.basevectors_qd(60, [15, 15, 15, 15], 100, coords='geo')
     for r in ret:
         assert r.shape == (2, 4)
-    ret = A.basevectors_qd(60, 15, [100, 100, 100, 100], coords='geo')
+    ret = apex_out.basevectors_qd(60, 15, [100, 100, 100, 100], coords='geo')
     for r in ret:
         assert r.shape == (2, 4)
 
@@ -946,10 +971,10 @@ def test_basevectors_qd_vectorization():
 # test array return values
 
 def test_basevectors_qd_array():
-    A = Apex(date=2000, refh=300)
-    f1, f2 = A.basevectors_qd([0, 30], 15, 100, coords='geo')
-    f1_lat0, f2_lat0 = A._basevec(0, 15, 100)
-    f1_lat30, f2_lat30 = A._basevec(30, 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    f1, f2 = apex_out.basevectors_qd([0, 30], 15, 100, coords='geo')
+    f1_lat0, f2_lat0 = apex_out._basevec(0, 15, 100)
+    f1_lat30, f2_lat30 = apex_out._basevec(30, 15, 100)
     assert_allclose(f1[:, 0], f1_lat0)
     assert_allclose(f2[:, 0], f2_lat0)
     assert_allclose(f1[:, 1], f1_lat30)
@@ -964,13 +989,13 @@ def test_basevectors_qd_array():
 # test against return from _geo2apexall for different coords
 
 def test_basevectors_apex_scalar_geo():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
 
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex(60, 15, 100, coords='geo')
+     e3) = apex_out.basevectors_apex(60, 15, 100, coords='geo')
 
     (_, _, _, _, f1_, f2_, _, d1_, d2_, d3_, _, e1_, e2_,
-     e3_) = A._geo2apexall(60, 15, 100)
+     e3_) = apex_out._geo2apexall(60, 15, 100)
 
     assert_allclose(f1, f1_)
     assert_allclose(f2, f2_)
@@ -983,14 +1008,14 @@ def test_basevectors_apex_scalar_geo():
 
 
 def test_basevectors_apex_scalar_apex():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
 
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex(60, 15, 100, coords='apex', precision=1e-2)
+     e3) = apex_out.basevectors_apex(60, 15, 100, coords='apex', precision=1e-2)
 
-    glat, glon, _ = A.apex2geo(60, 15, 100, precision=1e-2)
+    glat, glon, _ = apex_out.apex2geo(60, 15, 100, precision=1e-2)
     (_, _, _, _, f1_, f2_, _, d1_, d2_, d3_, _, e1_, e2_,
-     e3_) = A._geo2apexall(glat, glon, 100)
+     e3_) = apex_out._geo2apexall(glat, glon, 100)
 
     assert_allclose(f1, f1_)
     assert_allclose(f2, f2_)
@@ -1003,14 +1028,14 @@ def test_basevectors_apex_scalar_apex():
 
 
 def test_basevectors_apex_scalar_qd():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
 
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex(60, 15, 100, coords='qd', precision=1e-2)
+     e3) = apex_out.basevectors_apex(60, 15, 100, coords='qd', precision=1e-2)
 
-    glat, glon, _ = A.qd2geo(60, 15, 100, precision=1e-2)
+    glat, glon, _ = apex_out.qd2geo(60, 15, 100, precision=1e-2)
     (_, _, _, _, f1_, f2_, _, d1_, d2_, d3_, _, e1_, e2_,
-     e3_) = A._geo2apexall(glat, glon, 100)
+     e3_) = apex_out._geo2apexall(glat, glon, 100)
 
     assert_allclose(f1, f1_)
     assert_allclose(f2, f2_)
@@ -1025,8 +1050,8 @@ def test_basevectors_apex_scalar_qd():
 # test shapes and vectorization of arguments
 
 def test_basevectors_apex_scalar_shape():
-    A = Apex(date=2000, refh=300)
-    ret = A.basevectors_apex(60, 15, 100, precision=1e-2)
+    apex_out = Apex(date=2000, refh=300)
+    ret = apex_out.basevectors_apex(60, 15, 100, precision=1e-2)
     for r in ret[:2]:
         assert r.shape == (2,)
     for r in ret[2:]:
@@ -1034,18 +1059,18 @@ def test_basevectors_apex_scalar_shape():
 
 
 def test_basevectors_apex_vectorization():
-    A = Apex(date=2000, refh=300)
-    ret = A.basevectors_apex([60, 60, 60, 60], 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    ret = apex_out.basevectors_apex([60, 60, 60, 60], 15, 100)
     for r in ret[:2]:
         assert r.shape == (2, 4)
     for r in ret[2:]:
         assert r.shape == (3, 4)
-    ret = A.basevectors_apex(60, [15, 15, 15, 15], 100)
+    ret = apex_out.basevectors_apex(60, [15, 15, 15, 15], 100)
     for r in ret[:2]:
         assert r.shape == (2, 4)
     for r in ret[2:]:
         assert r.shape == (3, 4)
-    ret = A.basevectors_apex(60, 15, [100, 100, 100, 100])
+    ret = apex_out.basevectors_apex(60, 15, [100, 100, 100, 100])
     for r in ret[:2]:
         assert r.shape == (2, 4)
     for r in ret[2:]:
@@ -1054,13 +1079,13 @@ def test_basevectors_apex_vectorization():
 
 # test correct vectorization of height
 def test_basevectors_apex_vectorization_height():
-    A = Apex(date=2000, refh=0)
+    apex_out = Apex(date=2000, refh=0)
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex(60, 15, [200, 400], coords='geo')
+     e3) = apex_out.basevectors_apex(60, 15, [200, 400], coords='geo')
     (_, _, _, _, f1_1, f2_1, _, d1_1, d2_1, d3_1, _, e1_1, e2_1,
-     e3_1) = A._geo2apexall(60, 15, 200)
+     e3_1) = apex_out._geo2apexall(60, 15, 200)
     (_, _, _, _, f1_2, f2_2, _, d1_2, d2_2, d3_2, _, e1_2, e2_2,
-     e3_2) = A._geo2apexall(60, 15, 400)
+     e3_2) = apex_out._geo2apexall(60, 15, 400)
 
     assert_allclose(f1[:, 0], f1_1)
     assert_allclose(f2[:, 0], f2_1)
@@ -1100,12 +1125,12 @@ def test_basevectors_apex_vectorization_height():
 # test scalar return values
 
 def test_basevectors_apex_scalar():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
 
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex(0, 15, 100, coords='geo')
+     e3) = apex_out.basevectors_apex(0, 15, 100, coords='geo')
     (_, _, _, _, f1_1, f2_1, _, d1_1, d2_1, d3_1, _, e1_1, e2_1,
-     e3_1) = A._geo2apexall(0, 15, 100)
+     e3_1) = apex_out._geo2apexall(0, 15, 100)
 
     assert_allclose(f1, f1_1)
     assert_allclose(f2, f2_1)
@@ -1125,13 +1150,13 @@ def test_basevectors_apex_scalar():
 # test 1D array return values
 
 def test_basevectors_apex_array():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-     e3) = A.basevectors_apex([0, 30], 15, 100, coords='geo')
+     e3) = apex_out.basevectors_apex([0, 30], 15, 100, coords='geo')
     (_, _, _, _, f1_1, f2_1, _, d1_1, d2_1, d3_1, _, e1_1, e2_1,
-     e3_1) = A._geo2apexall(0, 15, 100)
+     e3_1) = apex_out._geo2apexall(0, 15, 100)
     (_, _, _, _, f1_2, f2_2, _, d1_2, d2_2, d3_2, _, e1_2, e2_2,
-     e3_2) = A._geo2apexall(30, 15, 100)
+     e3_2) = apex_out._geo2apexall(30, 15, 100)
 
     assert_allclose(f1[:, 0], f1_1)
     assert_allclose(f2[:, 0], f2_1)
@@ -1171,11 +1196,11 @@ def test_basevectors_apex_array():
 # test that vectors are calculated correctly
 
 def test_basevectors_apex_delta():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     for lat in range(0, 90, 10):
         for lon in range(0, 360, 15):
             (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-             e3) = A.basevectors_apex(lat, lon, 500)
+             e3) = apex_out.basevectors_apex(lat, lon, 500)
             f = [np.append(f1, 0), np.append(f2, 0), f3]
             g = [g1, g2, g3]
             d = [d1, d2, d3]
@@ -1187,10 +1212,10 @@ def test_basevectors_apex_delta():
 
 
 def test_basevectors_apex_invalid_scalar():
-    A = Apex(date=2000, refh=10000)
+    apex_out = Apex(date=2000, refh=10000)
     with warnings.catch_warnings(record=True) as w:
         (f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2,
-         e3) = A.basevectors_apex(0, 0, 0)
+         e3) = apex_out.basevectors_apex(0, 0, 0)
         assert issubclass(w[-1].category, UserWarning)
         assert 'set to -9999 where' in str(w[-1].message)
 
@@ -1215,21 +1240,22 @@ def test_basevectors_apex_invalid_scalar():
 
 
 def test_get_apex():
-    A = Apex(date=2000, refh=300)
-    assert_allclose(A.get_apex(10), 507.409702543805)
-    assert_allclose(A.get_apex(60), 20313.026999999987)
+    apex_out = Apex(date=2000, refh=300)
+    assert_allclose(apex_out.get_apex(10), 507.409702543805)
+    assert_allclose(apex_out.get_apex(60), 20313.026999999987)
 
 
 def test_get_apex_invalid_lat():
-    A = Apex(date=2000, refh=300)
+    apex_out = Apex(date=2000, refh=300)
     with pytest.raises(ValueError):
-        A.get_apex(91)
+        apex_out.get_apex(91)
     with pytest.raises(ValueError):
-        A.get_apex(-91)
-    A.get_apex(90)
-    A.get_apex(-90)
+        apex_out.get_apex(-91)
+    apex_out.get_apex(90)
+    apex_out.get_apex(-90)
 
-    assert_allclose(A.get_apex(90+1e-5), A.get_apex(90), rtol=0, atol=1e-8)
+    assert_allclose(apex_out.get_apex(90+1e-5), apex_out.get_apex(90),
+                    rtol=0, atol=1e-8)
 
 
 ###============================================================================
@@ -1238,18 +1264,18 @@ def test_get_apex_invalid_lat():
 
 
 def test_set_epoch():
-    A = Apex(date=2000.2, refh=300)
-    assert_allclose(A.year, 2000.2)
-    ret_2000_2_py = A._geo2apex(60, 15, 100)
-    A.set_epoch(2000.8)
-    assert_allclose(A.year, 2000.8)
-    ret_2000_8_py = A._geo2apex(60, 15, 100)
+    apex_out = Apex(date=2000.2, refh=300)
+    assert_allclose(apex_out.year, 2000.2)
+    ret_2000_2_py = apex_out._geo2apex(60, 15, 100)
+    apex_out.set_epoch(2000.8)
+    assert_allclose(apex_out.year, 2000.8)
+    ret_2000_8_py = apex_out._geo2apex(60, 15, 100)
 
     assert ret_2000_2_py != ret_2000_8_py
 
-    fa.loadapxsh(A.datafile, 2000.2)
+    fa.loadapxsh(apex_out.datafile, 2000.2)
     ret_2000_2_apex = fa.apxg2all(60, 15, 100, 300, 0)[2:4]
-    fa.loadapxsh(A.datafile, 2000.8)
+    fa.loadapxsh(apex_out.datafile, 2000.8)
     ret_2000_8_apex = fa.apxg2all(60, 15, 100, 300, 0)[2:4]
 
     assert ret_2000_2_apex != ret_2000_8_apex
@@ -1264,12 +1290,12 @@ def test_set_epoch():
 
 
 def test_set_refh():
-    A = Apex(date=2000, refh=300)
-    assert A.refh, 300
-    ret_300 = A._geo2apex(60, 15, 100)
-    A.set_refh(500)
-    assert A.refh == 500
-    ret_500 = A._geo2apex(60, 15, 100)
+    apex_out = Apex(date=2000, refh=300)
+    assert apex_out.refh, 300
+    ret_300 = apex_out._geo2apex(60, 15, 100)
+    apex_out.set_refh(500)
+    assert apex_out.refh == 500
+    ret_500 = apex_out._geo2apex(60, 15, 100)
 
     assert_allclose(ret_300, fa.apxg2all(60, 15, 100, 300, 0)[2:4])
     assert_allclose(ret_500, fa.apxg2all(60, 15, 100, 500, 0)[2:4])

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import, unicode_literals
+from __future__ import division, print_function, absolute_import
+from __future__ import unicode_literals
 
+import numpy as np
 import os
 import subprocess
 
-import numpy as np
-
 os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
-
 
 def setup_function(function):
     try:
-        os.remove('tests/output.txt')
+        outfile = 'tests/output.txt'
+        os.remove(outfile)
     except:
         pass
 
@@ -20,136 +20,142 @@ teardown_function = setup_function
 
 
 def test_module_invocation():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '2015',
-                          '--height', '300', '-i', 'tests/test_convert.txt',
-                          '-o', 'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '2015',
+                             '--height', '300', '-i', 'tests/test_convert.txt',
+                             '-o', outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [[57.469547, 93.639816],
                                       [58.522701, 94.044762],
                                       [59.571465, 94.477257]], rtol=1e-4)
 
 
 def test_convert_YYYY():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '2015',
-                          '--height', '300',
-                          '-i', 'tests/test_convert.txt', '-o',
-                          'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '2015',
+                             '--height', '300',
+                             '-i', 'tests/test_convert.txt', '-o', outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [[57.469547, 93.639816],
                                       [58.522701, 94.044762],
                                       [59.571465, 94.477257]], rtol=1e-4)
 
 
 def test_convert_YYYYMM():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '201501',
-                          '--height', '300', '-i', 'tests/test_convert.txt',
-                          '-o', 'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '201501',
+                             '--height', '300', '-i', 'tests/test_convert.txt',
+                             '-o', outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [[57.469547, 93.639816],
                                       [58.522701, 94.044762],
                                       [59.571465, 94.477257]], rtol=1e-4)
 
 
 def test_convert_YYYYMMDD():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex', '20150101',
-                          '--height', '300', '-i', 'tests/test_convert.txt',
-                          '-o', 'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex',
+                             '20150101', '--height', '300', '-i',
+                             'tests/test_convert.txt', '-o', outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [[57.469547, 93.639816],
                                       [58.522701, 94.044762],
                                       [59.571465, 94.477257]], rtol=1e-4)
 
 
 def test_convert_YYYYMMDDHHMMSS():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex',
-                          '20150101000000', '--height', '300', '-i',
-                          'tests/test_convert.txt', '-o', 'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex',
+                             '20150101000000', '--height', '300', '-i',
+                             'tests/test_convert.txt', '-o', outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [[57.469547, 93.639816],
                                       [58.522701, 94.044762],
                                       [59.571465, 94.477257]], rtol=1e-4)
 
 
 def test_convert_single_line():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex',
-                          '20150101000000', '--height', '300', '-i',
-                          'tests/test_convert_single_line.txt', '-o',
-                          'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'apex',
+                             '20150101000000', '--height', '300', '-i',
+                             'tests/test_convert_single_line.txt', '-o',
+                             outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [57.469547, 93.639816], rtol=1e-4)
 
 
 def test_convert_stdin_stdout():
-    p = subprocess.Popen('echo 60 15 | apexpy geo apex 2015 --height 300',
-                         shell=True, stdout=subprocess.PIPE)
-    stdout, _ = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo apex 2015 --height 300',
+                            shell=True, stdout=subprocess.PIPE)
+    stdout, _ = pipe.communicate()
+    pipe.wait()
     np.testing.assert_allclose(np.array(stdout.split(b' '), dtype=float),
                                [57.469547, 93.639816], rtol=1e-4)
 
 
 def test_convert_refh():
-    p = subprocess.Popen('echo 60 15 | apexpy geo apex 2000 --height 100 --refh=300', shell=True, stdout=subprocess.PIPE)
-    stdout, _ = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo apex 2000 --height 100 --refh=300', shell=True, stdout=subprocess.PIPE)
+    stdout, _ = pipe.communicate()
+    pipe.wait()
     np.testing.assert_allclose(np.array(stdout.split(b' '), dtype=float),
                                [55.94841766, 94.1068344], rtol=1e-4)
 
 
 def test_convert_mlt():
-    p = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'mlt',
-                          '20150101000000', '--height', '300', '-i',
-                          'tests/test_convert_single_line.txt', '-o',
-                          'tests/output.txt'])
-    p.communicate()
-    p.wait()
-    data = np.loadtxt('tests/output.txt')
+    pipe = subprocess.Popen(['python', '-m', 'apexpy', 'geo', 'mlt',
+                             '20150101000000', '--height', '300', '-i',
+                             'tests/test_convert_single_line.txt', '-o',
+                             outfile])
+    pipe.communicate()
+    pipe.wait()
+    assert os.path.isfile(outfile)
+    data = np.loadtxt(outfile)
     np.testing.assert_allclose(data, [57.469547, 1.06324], rtol=1e-4)
 
 
 def test_invalid_date():
-    p = subprocess.Popen('echo 60 15 | apexpy geo apex 201501010', shell=True,
-                         stderr=subprocess.PIPE)
-    _, stderr = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo apex 201501010',
+                            shell=True, stderr=subprocess.PIPE)
+    _, stderr = pipe.communicate()
+    pipe.wait()
     assert b'ValueError' in stderr
 
-    p = subprocess.Popen('echo 60 15 | apexpy geo apex 2015010100000',
-                         shell=True, stderr=subprocess.PIPE)
-    _, stderr = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo apex 2015010100000',
+                            shell=True, stderr=subprocess.PIPE)
+    _, stderr = pipe.communicate()
+    pipe.wait()
     assert b'ValueError' in stderr
 
 
 def test_mlt_nodatetime():
-    p = subprocess.Popen('echo 60 15 | apexpy geo mlt 20150101', shell=True,
-                         stderr=subprocess.PIPE)
-    _, stderr = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo mlt 20150101', shell=True,
+                            stderr=subprocess.PIPE)
+    _, stderr = pipe.communicate()
+    pipe.wait()
     assert b'ValueError' in stderr
 
 
 def test_invalid_coord():
-    p = subprocess.Popen('echo 60 15 | apexpy foobar apex 2015', shell=True,
-                         stderr=subprocess.PIPE)
-    _, stderr = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy foobar apex 2015', shell=True,
+                            stderr=subprocess.PIPE)
+    _, stderr = pipe.communicate()
+    pipe.wait()
     assert b'invalid choice' in stderr
 
-    p = subprocess.Popen('echo 60 15 | apexpy geo foobar 2015', shell=True,
-                         stderr=subprocess.PIPE)
-    _, stderr = p.communicate()
-    p.wait()
+    pipe = subprocess.Popen('echo 60 15 | apexpy geo foobar 2015', shell=True,
+                            stderr=subprocess.PIPE)
+    _, stderr = pipe.communicate()
+    pipe.wait()
     assert b'invalid choice' in stderr

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -8,10 +8,10 @@ import os
 import subprocess
 
 os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+outfile = 'tests/output.txt'
 
 def setup_function(function):
     try:
-        outfile = 'tests/output.txt'
         os.remove(outfile)
     except:
         pass


### PR DESCRIPTION
Helps users who encounter issues using the pip wheels due to libgfortran being installed in a different location and/or a different version of libgfortran than the location/version that the wheel was built with. See issue #10