### PR TITLE
PR to address #19

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,11 @@ build: off
 configuration: Release
 environment:
   matrix:
+    - TESTENV: 'check'
+      PYTHON_VERSION: '3.7'
+      MINICONDA_HOME: 'C:\Miniconda'
+      TESTSCRIPT: 'python setup.py check --strict --metadata --restructuredtext && check-manifest && flake8 src tests'
+      INSTALL_EXTRA_DEPS: 'pip install docutils check-manifest flake8 readme pygments sphinx_rtd_theme'
     - TESTENV: '2.7-nocover-64'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda-x64
@@ -53,11 +58,6 @@ environment:
       MINICONDA_HOME: C:\Miniconda
       TESTSCRIPT: 'python -m pytest'
 
-    - TESTENV: 'check'
-      PYTHON_VERSION: '3.7'
-      MINICONDA_HOME: 'C:\Miniconda'
-      TESTSCRIPT: 'python setup.py check --strict --metadata --restructuredtext && check-manifest && flake8 src tests'
-      INSTALL_EXTRA_DEPS: 'pip install docutils check-manifest flake8 readme pygments sphinx_rtd_theme'
 
 init:
   - ps: echo $env:TESTENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,52 +6,52 @@ environment:
     - TESTENV: '2.7-nocover-64'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '2.7-nocover-32'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.6-nocover-64'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.6-nocover-32'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.7-nocover-64'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.7-nocover-32'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.8-nocover-64'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.8-nocover-32'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.9-nocover-64'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '3.9-nocover-32'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: 'check'
       PYTHON_VERSION: '3.7'
@@ -99,4 +99,3 @@ artifacts:
 
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,52 +6,52 @@ environment:
     - TESTENV: '2.7-nocover-64'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '2.7-nocover-32'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.6-nocover-64'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.6-nocover-32'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.7-nocover-64'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.7-nocover-32'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.8-nocover-64'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.8-nocover-32'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.9-nocover-64'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '3.9-nocover-32'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: 'check'
       PYTHON_VERSION: '3.7'
@@ -99,3 +99,4 @@ artifacts:
 
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,52 +6,52 @@ environment:
     - TESTENV: '2.7-nocover-64'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '2.7-nocover-32'
       PYTHON_VERSION: '2.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.6-nocover-64'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.6-nocover-32'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.7-nocover-64'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.7-nocover-32'
       PYTHON_VERSION: '3.7'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.8-nocover-64'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.8-nocover-32'
       PYTHON_VERSION: '3.8'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.9-nocover-64'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '3.9-nocover-32'
       PYTHON_VERSION: '3.9'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: 'check'
       PYTHON_VERSION: '3.7'

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -7,12 +7,12 @@ environment:
     - TESTENV: '{{ env }}-64'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
     - TESTENV: '{{ env }}-32'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest tests'
+      TESTSCRIPT: 'py.test'
 
 {% endif %}{% endfor %}
     - TESTENV: 'check'

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -3,6 +3,11 @@ build: off
 configuration: Release
 environment:
   matrix:
+    - TESTENV: 'check'
+      PYTHON_VERSION: '3.7'
+      MINICONDA_HOME: 'C:\Miniconda'
+      TESTSCRIPT: 'python setup.py check --strict --metadata --restructuredtext && check-manifest && flake8 src tests'
+      INSTALL_EXTRA_DEPS: 'pip install docutils check-manifest flake8 readme pygments sphinx_rtd_theme'
 {% for env, config in tox_environments|dictsort %}{% if not config.cover %}
     - TESTENV: '{{ env }}-64'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
@@ -15,11 +20,6 @@ environment:
       TESTSCRIPT: 'python -m pytest'
 
 {% endif %}{% endfor %}
-    - TESTENV: 'check'
-      PYTHON_VERSION: '3.7'
-      MINICONDA_HOME: 'C:\Miniconda'
-      TESTSCRIPT: 'python setup.py check --strict --metadata --restructuredtext && check-manifest && flake8 src tests'
-      INSTALL_EXTRA_DEPS: 'pip install docutils check-manifest flake8 readme pygments sphinx_rtd_theme'
 
 init:
   - ps: echo $env:TESTENV

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -7,12 +7,12 @@ environment:
     - TESTENV: '{{ env }}-64'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
     - TESTENV: '{{ env }}-32'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'py.test'
+      TESTSCRIPT: 'python -m pytest'
 
 {% endif %}{% endfor %}
     - TESTENV: 'check'

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -7,12 +7,12 @@ environment:
     - TESTENV: '{{ env }}-64'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
     - TESTENV: '{{ env }}-32'
       PYTHON_VERSION: '{{ config.python[-3:] }}'
       MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
+      TESTSCRIPT: 'python -m pytest tests'
 
 {% endif %}{% endfor %}
     - TESTENV: 'check'

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,9 @@ console_scripts =
     apexpy = apexpy.__main__:main
 
 [options.package_data]
-apexpy = apexsh.dat
+apexpy =
+    apexsh.dat
+    igrf13coeffs.txt
 
 [aliases]
 release = register clean --all sdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,6 +109,7 @@ addopts =
   --doctest-modules
   --doctest-glob='*.rst'
   -rxEfsw
+  --strict
   --ignore=docs/conf.py
   --ignore=setup.py
   --ignore=.eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,6 @@ addopts =
   --doctest-modules
   --doctest-glob='*.rst'
   -rxEfsw
-  --strict
   --ignore=docs/conf.py
   --ignore=setup.py
   --ignore=.eggs

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -394,7 +394,7 @@ class Apex(object):
                 hA = height
             else:
                 estr = 'height {:.3g} is > apex height '.format(np.max(height)) +\
-                       '{:.3g} for alat {alat:.3g}'.format(hA)
+                       '{:.3g} for alat {:.3g}'.format(hA, alat)
                 raise ApexHeightError(estr)
 
         salat = np.sign(alat) if alat != 0 else 1

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -243,7 +243,7 @@ class Apex(object):
 
         alat, alon = self._geo2apex(glat, glon, height)
 
-        alat = np.float64(alat)
+        print(alat)
         if np.any(alat == -9999):
             warnings.warn('Apex latitude set to NaN where undefined '
                           '(apex height may be < reference height)')

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -938,6 +938,8 @@ class Apex(object):
         self.year = np.float64(year)
         fa.loadapxsh(self.datafile, self.year)
         igrf_fn = os.path.join(os.path.dirname(__file__), 'igrf13coeffs.txt')
+        if not os.path.exists(igrf_fn):
+            raise OSError("File {} does not exist".format(igrf_fn))
         fa.cofrm(self.year, igrf_fn)
 
     def set_refh(self, refh):

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -243,6 +243,7 @@ class Apex(object):
 
         alat, alon = self._geo2apex(glat, glon, height)
 
+        alat = np.float64(alat)
         if np.any(alat == -9999):
             warnings.warn('Apex latitude set to NaN where undefined '
                           '(apex height may be < reference height)')

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -393,8 +393,8 @@ class Apex(object):
                 # allow for values that are close
                 hA = height
             else:
-                estr = f'height {np.max(height):.3g} is > apex height ' \
-                       f'{hA:.3g} for alat {alat:.3g}'
+                estr = 'height {:.3g} is > apex height '.format(np.max(height)) +\
+                       '{:.3g} for alat {alat:.3g}'.format(hA)
                 raise ApexHeightError(estr)
 
         salat = np.sign(alat) if alat != 0 else 1

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -393,8 +393,8 @@ class Apex(object):
                 # allow for values that are close
                 hA = height
             else:
-                estr = 'height {:.3g} is > apex height '.format(np.max(height)) +\
-                       '{:.3g} for alat {:.3g}'.format(hA, alat)
+                estr = 'height {:.3g} is > apex height'.format(np.max(height))\
+                       + ' {:.3g} for alat {:.3g}'.format(hA, alat)
                 raise ApexHeightError(estr)
 
         salat = np.sign(alat) if alat != 0 else 1

--- a/src/apexpy/apex.py
+++ b/src/apexpy/apex.py
@@ -243,7 +243,6 @@ class Apex(object):
 
         alat, alon = self._geo2apex(glat, glon, height)
 
-        print(alat)
         if np.any(alat == -9999):
             warnings.warn('Apex latitude set to NaN where undefined '
                           '(apex height may be < reference height)')

--- a/src/apexpy/helpers.py
+++ b/src/apexpy/helpers.py
@@ -33,6 +33,7 @@ def checklat(lat, name='lat'):
     """
     if np.any(np.abs(lat) > 90 + 1e-5):
         raise ValueError(name + ' must be in [-90, 90]')
+
     return np.clip(lat, -90.0, 90.0)
 
 

--- a/src/apexpy/helpers.py
+++ b/src/apexpy/helpers.py
@@ -31,26 +31,9 @@ def checklat(lat, name='lat'):
     ValueError
         if any values are too far outside the range [-90, 90]
     """
-
-    if np.all(np.float64(lat) >= -90) and np.all(np.float64(lat) <= 90):
-        return lat
-
-    if np.isscalar(lat):
-        if lat > 90 and np.isclose(lat, 90, rtol=0, atol=1e-4):
-            lat = 90
-            return lat
-        elif lat < -90 and np.isclose(lat, -90, rtol=0, atol=1e-4):
-            lat = -90
-            return lat
-    else:
-        lat = np.float64(lat)  # make sure we have an array, not list
-        lat[(lat > 90) & (np.isclose(lat, 90, rtol=0, atol=1e-4))] = 90
-        lat[(lat < -90) & (np.isclose(lat, -90, rtol=0, atol=1e-4))] = -90
-        if np.all(lat >= -90) and np.all(lat <= 90):
-            return lat
-
-    # we haven't returned yet, so raise exception
-    raise ValueError(name + ' must be in [-90, 90]')
+    if np.any(np.abs(lat) > 90 + 1e-5):
+        raise ValueError(name + ' must be in [-90, 90]')
+    return np.clip(lat, -90.0, 90.0)
 
 
 def getsinIm(alat):

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -1321,7 +1321,6 @@ def test_set_epoch():
 
 def test_set_epoch_file_error():
     """Test raises OSError when IGRF coefficient file is missing."""
-
     # Ensure the coefficient file exists
     igrf_file = os.path.join(os.path.dirname(helpers.__file__),
                              'igrf13coeffs.txt')
@@ -1332,7 +1331,7 @@ def test_set_epoch_file_error():
     os.rename(igrf_file, tmp_file)
 
     # Test missing coefficient file failure
-    with pytest.Raises(OSError) as oerr:
+    with pytest.raises(OSError) as oerr:
         Apex(date=2000.2, refh=300)
 
     assert str(oerr.value).startswith(

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -4,10 +4,10 @@ from __future__ import division, absolute_import, unicode_literals
 
 import datetime as dt
 import itertools
-
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose
+import os
+import pytest
 
 from apexpy import fortranapex as fa
 from apexpy import Apex, ApexHeightError, helpers
@@ -1298,6 +1298,7 @@ def test_get_apex_invalid_lat():
 
 
 def test_set_epoch():
+    """Test successful setting of Apex epoch."""
     apex_out = Apex(date=2000.2, refh=300)
     assert_allclose(apex_out.year, 2000.2)
     ret_2000_2_py = apex_out._geo2apex(60, 15, 100)
@@ -1316,6 +1317,29 @@ def test_set_epoch():
 
     assert_allclose(ret_2000_2_py, ret_2000_2_apex)
     assert_allclose(ret_2000_8_py, ret_2000_8_apex)
+
+
+def test_set_epoch_file_error():
+    """Test raises OSError when IGRF coefficient file is missing."""
+
+    # Ensure the coefficient file exists
+    igrf_file = os.path.join(os.path.dirname(helpers.__file__),
+                             'igrf13coeffs.txt')
+    tmp_file = "temp_coeff.txt"
+    assert os.path.isfile(igrf_file)
+
+    # Move the coefficient file
+    os.rename(igrf_file, tmp_file)
+
+    # Test missing coefficient file failure
+    with pytest.Raises(OSError) as oerr:
+        Apex(date=2000.2, refh=300)
+
+    assert str(oerr.value).startswith(
+        "File {:} does not exist".format(igrf_file))
+
+    # Move the coefficient file back
+    os.rename(tmp_file, igrf_file)
 
 
 # ============================================================================

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -311,7 +311,7 @@ def test_convert_qd2apex():
 
 
 def test_convert_qd2apex_at_equator():
-    """Test the quasi-dipole to apex conversion at the magnetic equator"""
+    """Test the quasi-dipole to apex conversion at the magnetic equator."""
     apex_out = Apex(date=2000, refh=80)
     elat, elon = apex_out.convert(lat=0.0, lon=0, source='qd', dest='apex',
                                   height=120.0)
@@ -384,7 +384,7 @@ coord_names = ['geo', 'apex', 'qd']
 @pytest.mark.parametrize('transform', itertools.product(coord_names,
                                                         coord_names))
 def test_convert_withnan(transform):
-    """Test Apex.convert success with NaN input"""
+    """Test Apex.convert success with NaN input."""
     num_nans = 5
     in_lat = np.arange(0, 10, dtype=float)
     in_lat[:num_nans] = np.nan
@@ -433,8 +433,7 @@ def test_geo2apex_invalid_lat():
 
 
 def test_geo2apex_undefined_warning(recwarn):
-    """Test warning and fill values for an undefined location
-    """
+    """Test warning and fill values for an undefined location."""
     apex_out = Apex(date=2000, refh=10000)
     ret = apex_out.geo2apex(0, 0, 0)
 
@@ -805,8 +804,7 @@ def test_map_to_height_same_height():
 
 
 def test_map_to_height_conjugate():
-    """Test results of map_to_height using conjugacy
-    """
+    """Test results of map_to_height using conjugacy."""
     apex_out = Apex(date=2000, refh=300)
     assert_allclose(apex_out.map_to_height(60, 15, 100, 10000, conjugate=True,
                                            precision=1e-10),
@@ -1254,7 +1252,7 @@ def test_basevectors_apex_delta():
 
 
 def test_basevectors_apex_invalid_scalar(recwarn):
-    """ Test warning and fill values for calculating base vectors with bad value
+    """Test warning and fill values for calculating base vectors with bad value.
     """
     apex_out = Apex(date=2000, refh=10000)
     base_vecs = apex_out.basevectors_apex(0, 0, 0)

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -384,18 +384,19 @@ coord_names = ['geo', 'apex', 'qd']
 @pytest.mark.parametrize('transform', itertools.product(coord_names,
                                                         coord_names))
 def test_convert_withnan(transform):
-    N_nans = 5
+    """Test Apex.convert success with NaN input"""
+    num_nans = 5
     in_lat = np.arange(0, 10, dtype=float)
-    in_lat[:N_nans] = np.nan
+    in_lat[:num_nans] = np.nan
     in_lon = np.arange(0, 10, dtype=float)
-    in_lon[:N_nans] = np.nan
+    in_lon[:num_nans] = np.nan
     src, dest = transform
     apex_out = Apex(date=2000, refh=80)
     out_lat, out_lon = apex_out.convert(in_lat, in_lon, src, dest, height=120)
-    assert np.all(np.isnan(out_lat[:N_nans]))
-    assert np.all(np.isnan(out_lon[:N_nans]))
-    assert np.all(np.isfinite(out_lat[N_nans:]))
-    assert np.all(np.isfinite(out_lat[N_nans:]))
+    assert np.all(np.isnan(out_lat[:num_nans]))
+    assert np.all(np.isnan(out_lon[:num_nans]))
+    assert np.all(np.isfinite(out_lat[num_nans:]))
+    assert np.all(np.isfinite(out_lat[num_nans:]))
 
 
 # ============================================================================

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -3,7 +3,6 @@
 from __future__ import division, absolute_import, unicode_literals
 
 import datetime as dt
-import warnings
 import itertools
 
 import numpy as np
@@ -382,7 +381,8 @@ def test_convert_invalid_transformation():
 coord_names = ['geo', 'apex', 'qd']
 
 
-@pytest.mark.parametrize('transform', itertools.product(coord_names, coord_names))
+@pytest.mark.parametrize('transform', itertools.product(coord_names,
+                                                        coord_names))
 def test_convert_withnan(transform):
     N_nans = 5
     in_lat = np.arange(0, 10, dtype=float)

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -431,17 +431,16 @@ def test_geo2apex_invalid_lat():
                     apex_out.geo2apex(90, 0, 0), rtol=0, atol=1e-8)
 
 
-def test_geo2apex_undefined_warning():
+def test_geo2apex_undefined_warning(recwarn):
     """Test warning and fill values for an undefined location
     """
-    with warnings.catch_warnings(record=True) as wmsg:
-        apex_out = Apex(date=2000, refh=10000)
-        ret = apex_out.geo2apex(0, 0, 0)
+    apex_out = Apex(date=2000, refh=10000)
+    ret = apex_out.geo2apex(0, 0, 0)
 
     assert np.isnan(ret[0])
-    assert len(wmsg) == 1
-    assert issubclass(wmsg[-1].category, UserWarning)
-    assert 'set to NaN where' in str(wmsg[-1].message)
+    assert len(recwarn) == 1
+    assert issubclass(recwarn[-1].category, UserWarning)
+    assert 'set to NaN where' in str(recwarn[-1].message)
 
 
 # ============================================================================
@@ -1253,15 +1252,14 @@ def test_basevectors_apex_delta():
                 assert_allclose(np.sum(d[i] * e[j]), delta, rtol=0, atol=1e-5)
 
 
-def test_basevectors_apex_invalid_scalar():
+def test_basevectors_apex_invalid_scalar(recwarn):
     """ Test warning and fill values for calculating base vectors with bad value
     """
     apex_out = Apex(date=2000, refh=10000)
-    with warnings.catch_warnings(record=True) as wmsg:
-        base_vecs = apex_out.basevectors_apex(0, 0, 0)
+    base_vecs = apex_out.basevectors_apex(0, 0, 0)
 
-    assert issubclass(wmsg[-1].category, UserWarning)
-    assert 'set to NaN where' in str(wmsg[-1].message)
+    assert issubclass(recwarn[-1].category, UserWarning)
+    assert 'set to NaN where' in str(recwarn[-1].message)
 
     invalid = np.ones(3) * np.nan
     for i, bvec in enumerate(base_vecs):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,10 +31,6 @@ def test_checklat_scalar():
     assert helpers.checklat(90 + 1e-5) == 90
     assert helpers.checklat(-90 - 1e-5) == -90
 
-    assert type(helpers.checklat(0.)) == float
-    assert type(helpers.checklat(0)) == int
-    assert type(helpers.checklat(90 + 1e-5)) == int
-
     with pytest.raises(ValueError):
         helpers.checklat(90 + 1e-4)
     with pytest.raises(ValueError):
@@ -54,14 +50,26 @@ def test_checklat_array():
     assert_allclose(helpers.checklat([-90 - 1e-5, -90, 0, 90, 90 + 1e-5]),
                     np.array([-90, -90, 0, 90, 90]), rtol=0, atol=1e-8)
 
-    assert type(helpers.checklat([0])) == list
-    assert type(helpers.checklat(np.array([0]))) == np.ndarray
-
     with pytest.raises(ValueError):
         helpers.checklat([-90 - 1e-4, -90, 0, 90, 90 + 1e-5])
 
     with pytest.raises(ValueError):
         helpers.checklat([-90 - 1e-5, -90, 0, 90, 90 + 1e-4])
+
+
+def test_checklat_withnan():
+    in_lat = np.array([-90 - 1e-5, -90, 0, 90, 90 + 1e-5, np.nan, np.nan])
+    fin_mask = np.isfinite(in_lat)
+    out_lat = helpers.checklat(in_lat)
+    assert_allclose(np.array([-90, -90, 0, 90, 90]), out_lat[fin_mask], rtol=0, atol=1e-8)
+
+    assert np.all(np.isnan(out_lat[~fin_mask]))
+
+    with pytest.raises(ValueError):
+        helpers.checklat([-90 - 1e-4, np.nan, np.nan, 90 + 1e-5])
+
+    with pytest.raises(ValueError):
+        helpers.checklat([-90 - 1e-5, np.nan, np.nan, 90 + 1e-4])
 
 
 # ============================================================================

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -200,5 +200,9 @@ def test_subsol_array():
         assert sslon[i] == true_sslon
 
 
+def test_fail():
+    assert False
+
+
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -61,7 +61,8 @@ def test_checklat_withnan():
     in_lat = np.array([-90 - 1e-5, -90, 0, 90, 90 + 1e-5, np.nan, np.nan])
     fin_mask = np.isfinite(in_lat)
     out_lat = helpers.checklat(in_lat)
-    assert_allclose(np.array([-90, -90, 0, 90, 90]), out_lat[fin_mask], rtol=0, atol=1e-8)
+    assert_allclose(np.array([-90, -90, 0, 90, 90]), out_lat[fin_mask],
+                    rtol=0, atol=1e-8)
 
     assert np.all(np.isnan(out_lat[~fin_mask]))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -25,7 +25,7 @@ from apexpy import helpers
 
 @pytest.mark.parametrize('lat', [(90), (0), (-90), (np.nan)])
 def test_checklat_scalar(lat):
-    """Test good latitude check with scalars"""
+    """Test good latitude check with scalars."""
     if np.isnan(lat):
         assert np.isnan(helpers.checklat(lat))
     else:
@@ -34,7 +34,7 @@ def test_checklat_scalar(lat):
 
 @pytest.mark.parametrize('lat', [(90 + 1e-5), (-90 - 1e-5)])
 def test_checklat_scalar_clip(lat):
-    """Test good latitude check with scalars just beyond the lat limits"""
+    """Test good latitude check with scalars just beyond the lat limits."""
     assert helpers.checklat(lat) == np.sign(lat) * np.floor(abs(lat))
 
 
@@ -46,7 +46,7 @@ def test_checklat_scalar_clip(lat):
                           ([[-90 - 1e-4, -90, np.nan, np.nan, 90 + 1e-5]],
                            'lat must be in')])
 def test_checklat_error(in_args, msg):
-    """Test bad latitude raises ValueError with appropriate message"""
+    """Test bad latitude raises ValueError with appropriate message."""
     with pytest.raises(ValueError) as verr:
         helpers.checklat(*in_args)
 
@@ -54,7 +54,7 @@ def test_checklat_error(in_args, msg):
 
 
 def test_checklat_array():
-    """Test good latitude with finite values"""
+    """Test good latitude with finite values."""
     assert_allclose(helpers.checklat([-90 - 1e-5, -90, 0, 90, 90 + 1e-5]),
                     np.array([-90, -90, 0, 90, 90]), rtol=0, atol=1e-8)
 
@@ -62,7 +62,7 @@ def test_checklat_array():
 
 
 def test_checklat_array_withnan():
-    """Test good latitude input mixed with NaNs"""
+    """Test good latitude input mixed with NaNs."""
 
     in_lat = np.array([-90 - 1e-5, -90, 0, 90, 90 + 1e-5, np.nan, np.nan])
     fin_mask = np.isfinite(in_lat)
@@ -166,7 +166,7 @@ def test_subsol():
 
 
 def datetime64_to_datetime(dt64):
-    """Convert numpy datetime64 object to a datetime datetime object
+    """Convert numpy datetime64 object to a datetime datetime object.
 
     Notes
     -----
@@ -183,7 +183,7 @@ def datetime64_to_datetime(dt64):
 
 
 def test_subsol_array():
-    """Verify subsolar point calculation using an array of np.datetime64
+    """Verify subsolar point calculation using an array of np.datetime64.
 
     Notes
     -----

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -200,9 +200,5 @@ def test_subsol_array():
         assert sslon[i] == true_sslon
 
 
-def test_fail():
-    assert False
-
-
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This PR has changes to address #19:
* changed `helpers.checklat` so it doesn't error on NaN input (NaNs will be left in place)
* change -9999 output to NaN to be consistent across various transformations and various invalid inputs
* added tests for `convert` and `checklat` to test out NaN inputs
* fixed issue related to #28 but for apex to qd

This PR also includes a fix for setup.cfg which prevented appveyor from running pytest. The problem was that `igrf13coeffs.txt` was missing, then `apexpy.Apex()` would silently fail because the error happens in fortran and just crashes python. I also added a check in `Apex.set_epoch` to avoid this particular silent failure in the future.