### PR TITLE
Deprecated Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.1.1 (2021-06-05)
+------------------
+* Removed Python 2 support
+* Updated community and package documentation
+
 1.1.0 (2021-03-05)
 ------------------
 * Adapted Fortran to read IRGF coefficients from a file (updated to IGRF-13)

--- a/README.rst
+++ b/README.rst
@@ -29,28 +29,33 @@ which requires both libgfortran and gfortran to be installed on your system.
 Conversion is done by creating an ``Apex`` object and using its methods to
 perform the desired calculations. Some simple examples::
 
-    >>> from apexpy import Apex
-    >>> from __future__ import print_function
-    >>> A = Apex(date=2015.3)  # datetime objects are also supported
-    >>> # geo to apex, scalar input
-    >>> mlat, mlon = A.convert(60, 15, 'geo', 'apex', height=300)
-    >>> print("{:.12f}, {:.12f}".format(mlat, mlon))
+    from apexpy import Apex
+    import datetime as dt
+    atime = dt.datetime(2015, 2, 10, 18, 0, 0)
+    apex15 = Apex(date=2015.3)  # dt.date and dt.datetime objects also work
+
+    # Geodetic to apex, scalar input
+    mlat, mlon = apex15.convert(60, 15, 'geo', 'apex', height=300)
+    print("{:.12f}, {:.12f}".format(mlat, mlon))
     57.477310180664, 93.590156555176
-    >>> # apex to geo, array input
-    >>> glat, glon = A.convert([90, -90], 0, 'apex', 'geo', height=0)
-    >>> print(["{:.12f}, {:.12f}".format(ll, glon[i]) for i,ll in enumerate(glat)])
+
+    # Apex to geodetic, array input
+    glat, glon = apex15.convert([90, -90], 0, 'apex', 'geo', height=0)
+    print(["{:.12f}, {:.12f}".format(ll, glon[i]) for i,ll in enumerate(glat)])
     ['83.103820800781, -84.526657104492', '-74.388252258301, 125.736274719238']
-    >>> # geo to MLT
-    >>> import datetime as dt
-    >>> mlat, mlt = A.convert(60, 15, 'geo', 'mlt', datetime=dt.datetime(2015, 2, 10, 18, 0, 0))
-    >>> print("{:.12f}, {:.12f}".format(mlat, mlt))
+
+    # Geodetic to magnetic local time
+    mlat, mlt = apex15.convert(60, 15, 'geo', 'mlt', datetime=atime)
+    print("{:.12f}, {:.12f}".format(mlat, mlt))
     56.598316192627, 19.107861709595
-    >>> # can also convert magnetic longitude to mlt
-    >>> mlt = A.mlon2mlt(120, dt.datetime(2015, 2, 10, 18, 0, 0))
-    >>> print("{:.2f}".format(mlt))
+
+    # can also convert magnetic longitude to mlt
+    mlt = apex15.mlon2mlt(120, atime)
+    print("{:.2f}".format(mlt))
     20.90
 
-If you don't know or use Python, you can also use the command line. See details in the full documentation.
+If you don't know or use Python, you can also use the command line. See details
+in the full documentation.
 
 Documentation
 =============
@@ -88,7 +93,7 @@ Badges
         | |wheel| |supported-implementations|
 
 .. |docs| image:: https://readthedocs.org/projects/apexpy/badge/?style=flat
-    :target: https://readthedocs.org/projects/apexpy
+    :target: https://apexpy.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. |travis| image:: https://travis-ci.org/aburrell/apexpy.svg?branch=main

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,16 +8,6 @@ environment:
       MINICONDA_HOME: 'C:\Miniconda'
       TESTSCRIPT: 'python setup.py check --strict --metadata --restructuredtext && check-manifest && flake8 src tests'
       INSTALL_EXTRA_DEPS: 'pip install docutils check-manifest flake8 readme pygments sphinx_rtd_theme'
-    - TESTENV: '2.7-nocover-64'
-      PYTHON_VERSION: '2.7'
-      MINICONDA_HOME: C:\Miniconda-x64
-      TESTSCRIPT: 'python -m pytest'
-
-    - TESTENV: '2.7-nocover-32'
-      PYTHON_VERSION: '2.7'
-      MINICONDA_HOME: C:\Miniconda
-      TESTSCRIPT: 'python -m pytest'
-
     - TESTENV: '3.6-nocover-64'
       PYTHON_VERSION: '3.6'
       MINICONDA_HOME: C:\Miniconda-x64

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,10 +33,13 @@ This is the default option for Linux, and so should not be an issue there. On
 Windows with the Mingw32 compiler, you might find `this information <https://wiki.python.org/moin/WindowsCompilers#GCC_-_MinGW-w64_.28x86.2C_x64.29>`_
 useful for helping build apexpy.
 
+ApexPy is not compatible with numpy version 1.19.X, older and newer versions
+of numpy work without issue.
+
 The package has been tested with the following setups (others might work, too):
 
 * Windows (32/64 bit Python), Linux (64 bit), and Mac (64 bit)
-* Python 2.7, 3.6, 3.7, 3.8, 3.9
+* Python 3.6, 3.7, 3.8, 3.9
 
 
 .. _installation-cmd:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
   Operating System :: Microsoft :: Windows
   Operating System :: MacOS :: MacOS X
   Programming Language :: Python
-  Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
@@ -40,6 +39,7 @@ classifiers =
 
 [options]
 zip_safe = False
+packages = find:
 package_dir =
   =src
 install_requires = numpy
@@ -147,7 +147,6 @@ multi_line_output = 0
 #  - can use as many you want
 
 python_versions =
-    2.7
     3.6
     3.7
     3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
   Operating System :: Microsoft :: Windows
   Operating System :: MacOS :: MacOS X
   Programming Language :: Python
-  Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
@@ -147,7 +146,6 @@ multi_line_output = 0
 #  - can use as many you want
 
 python_versions =
-    2.7
     3.6
     3.7
     3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
   Operating System :: Microsoft :: Windows
   Operating System :: MacOS :: MacOS X
   Programming Language :: Python
+  Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
@@ -39,7 +40,6 @@ classifiers =
 
 [options]
 zip_safe = False
-packages = find:
 package_dir =
   =src
 install_requires = numpy
@@ -147,6 +147,7 @@ multi_line_output = 0
 #  - can use as many you want
 
 python_versions =
+    2.7
     3.6
     3.7
     3.8

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-from __future__ import absolute_import
-
 from glob import glob
 from os import path, environ
-from setuptools import setup, find_packages
+from setuptools import setup
 
 # Include extensions only when not on readthedocs.org
 if environ.get('READTHEDOCS', None) == 'True':
@@ -22,7 +20,6 @@ else:
 
 setup_kwargs = {'py_modules': [path.splitext(path.basename(pp))[0]
                                for pp in glob('src/*.py')],
-                'ext_modules': extensions,
-                'packages': find_packages(where='src')}
+                'ext_modules': extensions}
 
 setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
 from glob import glob
 from os import path, environ
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Include extensions only when not on readthedocs.org
 if environ.get('READTHEDOCS', None) == 'True':
@@ -20,6 +22,7 @@ else:
 
 setup_kwargs = {'py_modules': [path.splitext(path.basename(pp))[0]
                                for pp in glob('src/*.py')],
-                'ext_modules': extensions}
+                'ext_modules': extensions,
+                'packages': find_packages(where='src')}
 
 setup(**setup_kwargs)

--- a/src/apexpy/__init__.py
+++ b/src/apexpy/__init__.py
@@ -1,16 +1,15 @@
-from __future__ import absolute_import, division, print_function
+from sys import stderr
 
-from .apex import Apex, ApexHeightError
-from . import helpers
+from apexpy.apex import Apex, ApexHeightError
+from apexpy import helpers
 
 # Below try..catch required for autodoc to work on readthedocs
 try:
-    from . import fortranapex
+    from apexpy import fortranapex
 except ImportError:
-    print("".join(["ERROR: fortranapex module could not be imported. ",
-                   "apexpy probably won't work"]))
+    stderr.write("".join(["fortranapex module could not be imported. ",
+                          "apexpy probably won't work"]))
 
-
+# Define the global variables
 __version__ = "1.1.0"
-
 __all__ = ['Apex', 'fortranapex', 'helpers', 'ApexHeightError']

--- a/src/apexpy/__main__.py
+++ b/src/apexpy/__main__.py
@@ -1,29 +1,22 @@
 # -*- coding: utf-8 -*-
 
-"""Entry point for the CLI"""
+"""Entry point for the Command Line Interface"""
 
-from __future__ import division, absolute_import
-
-import sys
 import argparse
 import datetime as dt
 import numpy as np
+import sys
 
 import apexpy
 
-try:
-    # Python 3
-    STDIN = sys.stdin.buffer
-    STDOUT = sys.stdout.buffer
-except AttributeError:
-    # Python 2
-    STDIN = sys.stdin
-    STDOUT = sys.stdout
+STDIN = sys.stdin.buffer
+STDOUT = sys.stdout.buffer
 
 
 def main():
     """Entry point for the script"""
 
+    # Construct the description and parser for command-line arguments
     desc = 'Converts between geodetic, modified apex, quasi-dipole and MLT'
     parser = argparse.ArgumentParser(description=desc, prog='apexpy')
 
@@ -33,15 +26,14 @@ def main():
     parser.add_argument('dest', metavar='DEST',
                         choices=['geo', 'apex', 'qd', 'mlt'],
                         help='Convert to {geo, apex, qd, mlt}')
-    desc = 'YYYY[MM[DD[HHMMSS]]] date/time for IGRF coefficients, time part '
-    desc += 'required for MLT calculations'
+    desc = ''.join(['YYYY[MM[DD[HHMMSS]]] date/time for IGRF coefficients, ',
+                    'time part required for MLT calculations'])
     parser.add_argument('date', metavar='DATE', help=desc)
     parser.add_argument('--height', dest='height', default=0, metavar='HEIGHT',
                         type=float, help='height for conversion')
     parser.add_argument('--refh', dest='refh', metavar='REFH', type=float,
                         default=0,
                         help='reference height for modified apex coordinates')
-
     parser.add_argument('-i', '--input', dest='file_in', metavar='FILE_IN',
                         type=argparse.FileType('r'), default=STDIN,
                         help='input file (stdin if none specified)')
@@ -49,10 +41,11 @@ def main():
                         type=argparse.FileType('wb'), default=STDOUT,
                         help='output file (stdout if none specified)')
 
+    # Get the command line arguements
     args = parser.parse_args()
+    arg_array = np.loadtxt(args.file_in, ndmin=2)
 
-    array = np.loadtxt(args.file_in, ndmin=2)
-
+    # Test the input arguments
     if 'mlt' in [args.source, args.dest] and len(args.date) < 14:
         desc = 'full date/time YYYYMMDDHHMMSS required for MLT calculations'
         raise ValueError(desc)
@@ -60,12 +53,20 @@ def main():
         desc = 'full date/time must be given as YYYYMMDDHHMMSS, not ' \
                + 'YYYYMMDDHHMMSS'[:len(args.date)]
         raise ValueError(desc)
-    datetime = dt.datetime.strptime(args.date,
-                                    '%Y%m%d%H%M%S'[:len(args.date) - 2])
-    A = apexpy.Apex(date=datetime, refh=args.refh)
-    lats, lons = A.convert(array[:, 0], array[:, 1], args.source, args.dest,
-                           args.height, datetime=datetime)
+
+    # Format the time input
+    in_time = dt.datetime.strptime(args.date,
+                                   '%Y%m%d%H%M%S'[:len(args.date) - 2])
+
+    # Run the desired apex conversion
+    apex_obj = apexpy.Apex(date=in_time, refh=args.refh)
+    lats, lons = apex_obj.convert(arg_array[:, 0], arg_array[:, 1], args.source,
+                                  args.dest, args.height, datetime=in_time)
+
+    # Save the output to a file
     np.savetxt(args.file_out, np.column_stack((lats, lons)), fmt='%.8f')
+
+    return
 
 
 if __name__ == '__main__':

--- a/src/apexpy/helpers.py
+++ b/src/apexpy/helpers.py
@@ -2,11 +2,9 @@
 
 """This module contains helper functions used by :class:`~apexpy.Apex`."""
 
-from __future__ import division, print_function, absolute_import
-
-import time
 import datetime as dt
 import numpy as np
+import time
 
 
 def checklat(lat, name='lat'):
@@ -30,9 +28,10 @@ def checklat(lat, name='lat'):
     ------
     ValueError
         if any values are too far outside the range [-90, 90]
+
     """
     if np.any(np.abs(lat) > 90 + 1e-5):
-        raise ValueError(name + ' must be in [-90, 90]')
+        raise ValueError('{:} must be in [-90, 90]'.format(name))
 
     return np.clip(lat, -90.0, 90.0)
 
@@ -84,6 +83,7 @@ def toYearFraction(date):
     Parameters
     ----------
     date : :class:`datetime.date` or :class:`datetime.datetime`
+        Input date or datetime object
 
     Returns
     -------
@@ -99,6 +99,7 @@ def toYearFraction(date):
     def sinceEpoch(date):
         """returns seconds since epoch"""
         return time.mktime(date.timetuple())
+
     year = date.year
     startOfThisYear = dt.datetime(year=year, month=1, day=1)
     startOfNextYear = dt.datetime(year=year + 1, month=1, day=1)
@@ -107,7 +108,9 @@ def toYearFraction(date):
     yearDuration = sinceEpoch(startOfNextYear) - sinceEpoch(startOfThisYear)
     fraction = yearElapsed / yearDuration
 
-    return date.year + fraction
+    year += fraction
+
+    return year
 
 
 def gc2gdlat(gclat):

--- a/tests/test_Apex.py
+++ b/tests/test_Apex.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, absolute_import, unicode_literals
-
 import datetime as dt
 import itertools
 import numpy as np
@@ -1401,7 +1399,3 @@ def test_bvectors_apex():
         for j in range(output.size):
             assert_allclose(output.ravel()[j], expected[i].ravel()[j], rtol=0,
                             atol=1e-5)
-
-
-if __name__ == '__main__':
-    pytest.main()

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-from __future__ import unicode_literals
-
 import numpy as np
 import os
 import subprocess

--- a/tests/test_fortranapex.py
+++ b/tests/test_fortranapex.py
@@ -2,7 +2,6 @@
 
 from numpy.testing import assert_allclose
 import os
-import pytest
 
 import apexpy
 from apexpy import fortranapex as fa
@@ -77,7 +76,3 @@ def test_apxq2g_lowprecision():
     assert_allclose(glat, 51.00891876220703)
     assert_allclose(glon, -66.11973571777344)
     assert_allclose(error, -9999.0)
-
-
-if __name__ == '__main__':
-    pytest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, absolute_import, unicode_literals
-
 import datetime as dt
-
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose
+import pytest
 
 from apexpy import helpers
 
@@ -199,7 +196,3 @@ def test_subsol_array():
         true_sslat, true_sslon = helpers.subsol(datetime)
         assert sslat[i] == true_sslat
         assert sslon[i] == true_sslon
-
-
-if __name__ == '__main__':
-    pytest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist =
     clean,
     check,
-    2.7,
-    2.7-nocover,
     3.6,
     3.6-nocover,
     3.7,
@@ -99,30 +97,6 @@ commands = coverage erase
 skip_install = true
 usedevelop = false
 deps = coverage
-
-[testenv:2.7]
-basepython = {env:TOXPYTHON:python2.7}
-setenv =
-    {[testenv]setenv}
-    WITH_COVERAGE=yes
-    PY_CCOV=-coverage
-usedevelop = true
-commands =
-    python setup.py clean --all build_ext --force --inplace
-    python -m pytest {posargs:--cov --cov-report=term-missing -vv --doctest-glob='*.rst'}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-
-[testenv:2.7-nocover]
-basepython = {env:TOXPYTHON:python2.7}
-
-[testenv:2.7-buildonly-nocover]
-basepython = {env:TOXPYTHON:python2.7}
-deps =
-skip_install = true
-commands =
 
 [testenv:3.6]
 basepython = {env:TOXPYTHON:python3.6}


### PR DESCRIPTION
# Description

Removes support for Python 2 and clarifies installation instructions.

Fixes #38 and records issue noted in #68.

## Type of change

- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Ran unit tests

**Test Configuration**:
* Operating system: OS X Mojave
* Python version number: 3.7
* Compiler with version number: MacPorts gcc9 9.3.0_4

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
