### PR TITLE
Build wheels for all OS using CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,24 +97,13 @@ jobs:
            coverage report -m
            coveralls --rcfile=apexpy\setup.cfg --service=github
 
-  build_wheels:
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.2
-      with:
-        package-dir: .
-        output-dir: wheelhouse
-        config-file: "pyproject.toml"
+    - name: Create a Windows wheel
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+           mkdir dist
+           pip wheel -w dist
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
-         path: ./wheelhouse/*.whl
+         path: ./apexpy/dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
           brew reinstall gcc
           python -m build .
           pip install .
+	  ls dist
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -102,8 +103,10 @@ jobs:
       run: |
            mkdir dist
            pip wheel . -w dist
+	   dir dist
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
-         path: ./apexpy/dist/*.whl
+         path: dist/*.whl
+         if-no-files-found: warning

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            mkdir dist
-           pip wheel -w dist
+           pip wheel . -w dist
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
           brew reinstall gcc
           python -m build .
           pip install .
-          ls dist
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -103,10 +102,9 @@ jobs:
       run: |
            mkdir dist
            pip wheel . -w dist
-           dir dist
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
          path: dist/*.whl
-         if-no-files-found: warning
+         if-no-files-found: warn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,3 +96,25 @@ jobs:
            coverage combine
            coverage report -m
            coveralls --rcfile=apexpy\setup.cfg --service=github
+
+  build_wheels:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.11.2
+      with:
+        package-dir: .
+        output-dir: wheelhouse
+        config-file: "pyproject.toml"
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+         path: ./wheelhouse/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           brew reinstall gcc
           python -m build .
           pip install .
-	  ls dist
+          ls dist
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -103,7 +103,7 @@ jobs:
       run: |
            mkdir dist
            pip wheel . -w dist
-	   dir dist
+           dir dist
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 * Fixed missing microseconds bug in helpers.subsol
 * Added function to calculate height along a field line
 * Changed installation to use meson
+* Added wheel creation to CI
 
 1.1.0 (2021-03-05)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changelog
 * Added function to calculate height along a field line
 * Changed installation to use meson
 * Added wheel creation to CI
+* Updated flake8 ignore syntax
 
 1.1.0 (2021-03-05)
 ------------------

--- a/apexpy/__init__.py
+++ b/apexpy/__init__.py
@@ -2,14 +2,14 @@ from sys import stderr
 
 # Below try..catch required for autodoc to work on readthedocs
 try:
-    from apexpy import fortranapex
+    from apexpy import fortranapex  # noqa F401
 except ImportError as ierr:
     stderr.write("".join(["fortranapex module could not be imported. ",
                           "apexpy probably won't work. Failed with error: ",
                           str(ierr)]))
 
-from apexpy.apex import Apex, ApexHeightError
-from apexpy import helpers
+from apexpy.apex import Apex, ApexHeightError  # noqa F401
+from apexpy import helpers  # noqa F401
 
 # Define the global variables
 __version__ = "1.1.0"

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -1,6 +1,25 @@
 Package Maintenance
 ===================
 
+Providing Wheels with Releases
+------------------------------
+
+The Continuous Integration (CI) now saves wheels created for each tested Python
+version and computer Operating System (OS) as artifacts. When preparing a new
+PyPi release, these wheels should be downloaded from the release candidate.
+The list of artifacts may be found
+`here <https://api.github.com/repos/aburrell/apexpy/actions/artifacts>`_.
+
+To download an artifact:
+
+1. run ``curl -v -H "Authorization: token <GITHUB-ACCESS-TOKEN>" https://api.github.com/repos/aburrell/apexpy/actions/artifacts/<ARTIFACT-ID>/zip``, where
+   <ITEM> should be replaced with the appropriate item string.
+2. Copy the URL from the ``Location`` output produced by the previous command
+   into a browser, which will download a zip archive into your standard
+   download location.
+3. Copy the zip archive into the ``apexpy/dist`` directory and unzip.
+4. Check the archive for the expected matrix of *.whl objects
+
 Updating IGRF
 -------------
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -12,13 +12,16 @@ The list of artifacts may be found
 
 To download an artifact:
 
-1. run ``curl -v -H "Authorization: token <GITHUB-ACCESS-TOKEN>" https://api.github.com/repos/aburrell/apexpy/actions/artifacts/<ARTIFACT-ID>/zip``, where
+1. If you don't have a GitHub Personal Access Token, follow
+   `these instructions <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+   to create one.
+2. Run ``curl -v -H "Authorization: token <GITHUB-ACCESS-TOKEN>" https://api.github.com/repos/aburrell/apexpy/actions/artifacts/<ARTIFACT-ID>/zip``, where
    <ITEM> should be replaced with the appropriate item string.
-2. Copy the URL from the ``Location`` output produced by the previous command
+3. Copy the URL from the ``Location`` output produced by the previous command
    into a browser, which will download a zip archive into your standard
    download location.
-3. Copy the zip archive into the ``apexpy/dist`` directory and unzip.
-4. Check the archive for the expected matrix of *.whl objects
+4. Copy the zip archive into the ``apexpy/dist`` directory and unzip.
+5. Check the archive for the expected matrix of *.whl objects
 
 Updating IGRF
 -------------

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -19,7 +19,7 @@ To download an artifact:
    <ITEM> should be replaced with the appropriate item string.
 3. Copy the URL from the ``Location`` output produced by the previous command
    into a browser, which will download a zip archive into your standard
-   download location.
+   download location. Alternatively (or if this doesn't work) you can use `wget` to retrieve the archive.
 4. Copy the zip archive into the ``apexpy/dist`` directory and unzip.
 5. Check the archive for the expected matrix of *.whl objects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dynamic = ['version']
 [tool.project.scripts]
 apexpy = {reference = 'apexpy.__main__:main', type = 'console'}
 
+[tool.cibuildwheel]
+before-all = "apt install libpng-dev"
+
 [project.optional-dependencies]
 test = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,6 @@ dynamic = ['version']
 [tool.project.scripts]
 apexpy = {reference = 'apexpy.__main__:main', type = 'console'}
 
-[tool.cibuildwheel]
-before-all = "apt install libpng-dev"
-
 [project.optional-dependencies]
 test = [
   "pytest",

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ omit = *migrations*
 
 [flake8]
 max-line-length = 80
-exclude = */migrations/*,build/*
+exclude = */migrations/*,build/*,setup.py
 ignore = W503
-       setup.py F811
-       apexpy/__init__.py F401
+         apexpy/__init__.py F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,4 +68,3 @@ omit = *migrations*
 max-line-length = 80
 exclude = */migrations/*,build/*,setup.py
 ignore = W503
-         apexpy/__init__.py F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,6 @@ omit = *migrations*
 [flake8]
 max-line-length = 80
 exclude = */migrations/*,build/*
-ignore = *.py W503
+ignore = W503
        setup.py F811
        apexpy/__init__.py F401


### PR DESCRIPTION
# Description

Partially addresses #85 by using cibuildwheels to create more wheels for installing apexpy.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Needs CI to test

**Test Configuration**:
* Operating system: GitHub Actions
* Python version number: N/A
* Compiler with version number: N/A
* Any details about your local setup that are relevant (e.g., apexpy version/branch)

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
