### PR TITLE
DOC: Updates to installation documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -92,7 +92,7 @@ seemly successful installation with apexpy reporting that fortranapex cannot be
 imported.
 
 ::
-   LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" python setup.py install
+   LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" pip install apexpy
 
 Windows systems are known to have issues with Fortran-based codes.  The Windows
 testing we do uses miniconda, so we recommend using the Anaconda environment.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,23 +3,19 @@
 Installation
 ============
 
-This package requires NumPy, which you can install alone or as a part of SciPy.
-`Some Python distributions <https://scipy.org/install/>`_
-come with NumPy/SciPy pre-installed. For Python distributions without
-NumPy/SciPy, Windows/Mac users should install
-`pre-compiled binaries of NumPy/SciPy <https://scipy.org/download/#official-source-and-binary-releases>`_, and Linux users may have
-NumPy/SciPy available in `their repositories <https://scipy.org/download/>`_.
+.. _installation-cmd:
 
-When you have NumPy, you may use either PyPI or GitHub to install this package.
+Standard Installation
+---------------------
 
-The code behind this package is written in Fortran.  Because of this, you
-**MUST** have a fortran compiler installed on your system before you attempt
-the next step.  `Gfortran <https://gcc.gnu.org/wiki/GFortran>`_ is a free
-compiler that can be installed, if one is not already available on your system.
-If you are installling this or MinGW in Windows, make sure you install it
-**after** installing the Windows Microsoft C++ Build tools.  The apexpy
-installation has been tested successfully with gfortran 7 and some more recent
-versions.  Earlier versions of gfortran may not work and are not recommended.
+The recommended (and most straightforward) method for users to install apexpy is
+through PyPI. From the command line use ``pip`` [1]_::
+
+    pip install apexpy
+
+You should be able to import apexpy and run basic conversions as shown in the
+examples.  If you get errors or warnings upon importing, see below for more
+advanced options and troubleshooting.
 
 
 .. _installation-tested:
@@ -33,28 +29,68 @@ The package has been tested with the following setups (others might work, too):
 * Python 3.7, 3.8, 3.9, 3.10
 
 
-.. _installation-pip:
+Advanced Installation
+---------------------
 
-PyPI
-----
-This is the most straightforward option!  From the command line use
-``pip`` [1]_::
+If you cannot install apexpy from the wheels available on PyPI, you will have to
+use one of the following more advanced options. These are generally only
+recommended if you are planning on developing or modifying the apexpy source
+code.
 
-    pip install apexpy
+The code behind this package is written in Fortran.  Because of this, you
+**MUST** have a fortran compiler installed on your system before you attempt
+the following steps.  `Gfortran <https://gcc.gnu.org/wiki/GFortran>`_ is a free
+compiler that can be installed, if one is not already available on your system.
+If you are installing this or MinGW in Windows, make sure you install it
+**after** installing the Windows Microsoft C++ Build tools.  The apexpy
+installation has been tested successfully with gfortran 7 and some more recent
+versions.  Earlier versions of gfortran may not work and are not recommended.
 
-Installation Issues
+Installation also requires gcc. `GCC <https://gcc.gnu.org/>`_ is a free compiler
+that can be installed from a variety of sources and standard package managers.
+It is recommended that you check to see if you have gcc available on your system
+before installing as it is relatively common and multiple competing versions
+may cause problems if paths are not managed carefully.
+
+This package requires NumPy, which you can install alone or as a part of SciPy.
+`Some Python distributions <https://scipy.org/install/>`_
+come with NumPy/SciPy pre-installed. For Python distributions without
+NumPy/SciPy, Windows/Mac users should install
+`pre-compiled binaries of NumPy/SciPy <https://scipy.org/download/#official-source-and-binary-releases>`_, and Linux users may have
+NumPy/SciPy available in `their repositories <https://scipy.org/download/>`_.
+Pip should install NumPy automatically when installing apexpy, but if not,
+install it manually before attempting to install apexpy. Apexpy is not
+compatible with NumPy version 1.19.X, older and newer versions of NumPy work
+without issue.
+
+**IMPORTANT:** If you are struggling with installing apexpy and trying some of
+the following options, it is recommended that you user the ``--no-cache`` flag
+with pip to avoid repeatedly reinstalling the same non-functional build.
+
+
+Install from GitHub
 ^^^^^^^^^^^^^^^^^^^
 
-Because the base code is in Fortran, installation can be tricky and different
-problems can arise even if you already have a compiler installed (but please
-check that you do before trying these solutions).
+Apexpy can be installed from the source code on GitHub, so long as a fortran
+compiler is available::
 
-ApexPy is not compatible with numpy version 1.19.X, older and newer versions
-of numpy work without issue.
+  pip install git+https://github.com/aburrell/apexpy.git
 
-Many times, the following modification to ``pip`` [1]_ will solve the
-installation problem, but it requires that both libgfortran and gfortran are
-installed on your system.::
+This is advantageous if you would like to install from a particular branch or
+tag instead of the latest published stable release on PyPI.  Do this by
+appending `@target-branch` to the end of the above command.  For instance, if
+you would like to install from the develop branch instead of main, the
+appropriate command would be::
+
+  pip install git+https://github.com/aburrell/apexpy.git@develop
+
+
+Install without Wheels
+^^^^^^^^^^^^^^^^^^^^^^
+
+Many times, skipping building wheels locally will solve installation problem,
+but it requires that both libgfortran and gfortran are installed on your
+system::
 
     pip install --no-binary :apexpy: apexpy
 
@@ -62,52 +98,13 @@ This is the default option for Linux, and so should not be an issue there. On
 Windows with the Mingw32 compiler, you might find `this information <https://wiki.python.org/moin/WindowsCompilers#GCC_-_MinGW-w64_.28x86.2C_x64.29>`_
 useful for helping build apexpy.
 
-Problems have also been encountered when installing in a conda environment.
-In this case, pip seems to ignore the installed numpy version when installing.
-This appears to result in a successful installation that fails upon import.  In
-this case, try::
 
-  pip install apexpy --no-build-isolation
+Build from Source
+^^^^^^^^^^^^^^^^^
 
-The specific fortran compiler to use can be specified with the `FC` flag.  This
-can be useful your system has multiple versions of gfortran and the default
-is not appropriate (ie., an older version).
-
-::
-   FC=/path/to/correct/gfortran pip install apexpy
-
-Apple Silicon systems require certain compliation flags to deal with memory
-problems.  In this case, the following command has worked (after first
-installing both gfortran and numpy).
-
-::
-   CFLAGS="-falign-functions=8 ${CFLAGS}" pip install --no-binary :apexpy: apexpy
-
-If you are on Apple and encounter a library error such as
-``ld: library not found for -lm``, you will need to provide an additional
-linking flag to the Mac OSX SDK library.  This example assumes you are building
-locally from the cloned Git repository.  Issues on Mac OS have also been
-encountered when using clang for ``CC`` alongside gfortran.  This resulted in a
-seemly successful installation with apexpy reporting that fortranapex cannot be
-imported.
-
-::
-   LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" pip install apexpy
-
-Windows systems are known to have issues with Fortran-based codes.  The Windows
-testing we do uses miniconda, so we recommend using the Anaconda environment.
-One problem that has been encountered is a lack of LAPACK/BLAS tools that
-causes numpy to not behave as expected.  This can be fixed by installing
-scipy before numpy and then installing apexpy.
-
-
-.. _installation-cmd:
-
-GitHub
-------
-If you are indending on modifying or contributing to apexpy, it's easier to
-install apexpy by forking the repository and installing it locally or within
-a virtual environment. After clonining the fork (see :ref:`contributing`),
+If you intend to modify or contribute to apexpy, you should install apexpy by
+forking the repository and installing it locally or within a virtual
+environment. After cloning the fork (see :ref:`contributing`),
 you may install by::
 
   cd apexpy
@@ -115,13 +112,7 @@ you may install by::
   pip install -e .
 
 
-The ``-e`` flag uses pip to peform what used to be ``python setup.py develop``.
-
-Another benefit of installing apexpy from the command line is specifying the
-compilers you would like to use.  These can be changed by altering the ``CC``
-and ``FC`` environment variables on your computer.  If using an Intel compiler,
-you will need to uncomment a line at the top of ``src/fortranapex/igrf.f90`` to
-ensure all necessary libraries are imported.
+The ``-e`` flag uses pip to perform what used to be ``python setup.py develop``.
 
 If the above command doesn't work for you (as may be the case for Windows), you
 can try::
@@ -131,6 +122,71 @@ can try::
   ninja -j 2 -C build
   cd build
   meson install
+
+
+Specifying Compilers
+^^^^^^^^^^^^^^^^^^^^
+
+When you install apexpy from the command line you can specify the compilers you
+would like to use.  These can be changed by altering the ``CC`` and ``FC``
+environment variables on your computer::
+
+  FC=/path/to/correct/gfortran CC=/path/to/correct/gcc pip install -e .
+
+This can be useful your system has multiple versions of gfortran or gcc and the
+default is not appropriate (ie., an older version). If using an Intel compiler,
+you will need to clone the repository locally and uncomment a line at the top of
+``src/fortranapex/igrf.f90`` to ensure all necessary libraries are imported.
+
+
+When All Else Fails
+^^^^^^^^^^^^^^^^^^^
+
+Because the base code is in Fortran, installation can be tricky and different
+problems can arise even if you already have a compiler installed.  The following
+are a series of installation commands that users have reported working for
+different system configurations.  We have not been able to reproduce some of
+the issues users report and cannot fully explain why some of the options work,
+none the less they are recorded here as they may be useful to other users.  If
+you feel like you can provide more insight on the situations where these
+commands are appropriate or discover a new installation process that works for
+your system when none of the previously described standard approaches work,
+please consider contributing to this documentation (see :ref:`contributing`).
+
+Problems have been encountered when installing in a conda environment. In this
+case, pip seems to ignore the installed numpy version when installing. This
+appears to result in a successful installation that fails upon import.  In
+this case, try::
+
+  pip install apexpy --no-build-isolation
+
+
+Apple Silicon systems require certain compilation flags to deal with memory
+problems. Apexpy may appear to install and import correctly, but then fail with
+BUS errors when used. In this case, the following command has worked::
+
+  CFLAGS="-falign-functions=8 ${CFLAGS}" pip install --no-binary :apexpy: apexpy
+
+
+If you are on Apple and encounter a library error such as
+``ld: library not found for -lm``, you will need to provide an additional
+linking flag to the Mac OSX SDK library::
+
+  LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" pip install .
+
+This example assumes you are building
+locally from the cloned Git repository.  Issues on Mac OS have also been
+encountered when using clang for ``CC`` alongside gfortran.  This resulted in a
+seemly successful installation with apexpy reporting that fortranapex cannot be
+imported.
+
+
+Windows systems are known to have issues with Fortran-based codes.  The Windows
+testing we do uses miniconda, so we recommend using the Anaconda environment.
+One problem that has been encountered is a lack of LAPACK/BLAS tools that
+causes numpy to not behave as expected.  This can be fixed by installing
+scipy before numpy and then installing apexpy.
+
 
 .. [1] pip is included with Python 2 from v2.7.9 and Python 3 from v3.4.
        If you don't have pip,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,8 +46,8 @@ If you are installing this or MinGW in Windows, make sure you install it
 installation has been tested successfully with gfortran 7 and some more recent
 versions.  Earlier versions of gfortran may not work and are not recommended.
 
-Installation also requires gcc. `GCC <https://gcc.gnu.org/>`_ is a free compiler
-that can be installed from a variety of sources and standard package managers.
+Installation also requires a C compiler of the same type as the fortran compiler. `GCC <https://gcc.gnu.org/>`_ is a free compiler that works goth Gfortran and
+can be installed from a variety of sources and standard package managers.
 It is recommended that you check to see if you have gcc available on your system
 before installing as it is relatively common and multiple competing versions
 may cause problems if paths are not managed carefully.
@@ -88,7 +88,7 @@ appropriate command would be::
 Install without Wheels
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Many times, skipping building wheels locally will solve installation problem,
+Many times, skipping building wheels locally will solve installation problems,
 but it requires that both libgfortran and gfortran are installed on your
 system::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,10 @@ The code behind this package is written in Fortran.  Because of this, you
 the next step.  `Gfortran <https://gcc.gnu.org/wiki/GFortran>`_ is a free
 compiler that can be installed, if one is not already available on your system.
 If you are installling this or MinGW in Windows, make sure you install it
-**after** installing the Windows Microsoft C++ Build tools.
+**after** installing the Windows Microsoft C++ Build tools.  The apexpy
+installation has been tested successfully with gfortran 7 and some more recent
+versions.  Earlier versions of gfortran may not work and are not recommended.
+
 
 .. _installation-tested:
 
@@ -60,13 +63,19 @@ Windows with the Mingw32 compiler, you might find `this information <https://wik
 useful for helping build apexpy.
 
 Problems have also been encountered when installing in a conda environment.
-In this case, pip seems to ignore the installed numby version when installing.
+In this case, pip seems to ignore the installed numpy version when installing.
 This appears to result in a successful installation that fails upon import.  In
 this case, try::
 
   pip install apexpy --no-build-isolation
 
-  
+The specific fortran compiler to use can be specified with the `FC` flag.  This
+can be useful your system has multiple versions of gfortran and the default
+is not appropriate (ie., an older version).
+
+::
+   FC=/path/to/correct/gfortran pip install apexpy
+
 Apple Silicon systems require certain compliation flags to deal with memory
 problems.  In this case, the following command has worked (after first
 installing both gfortran and numpy).
@@ -83,7 +92,7 @@ seemly successful installation with apexpy reporting that fortranapex cannot be
 imported.
 
 ::
-   LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" /opt/local/bin/python3.10 setup.py install
+   LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib ${LDFLAGS}" python setup.py install
 
 Windows systems are known to have issues with Fortran-based codes.  The Windows
 testing we do uses miniconda, so we recommend using the Anaconda environment.


### PR DESCRIPTION
# Description

This PR makes some updates and clarifications to the apexpy installation instructions, specifically troubleshooting unusual cases.  Addresses https://github.com/aburrell/apexpy/issues/101 by specifying apexpy has not been tested with versions of gfortran below v7.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change is a documentation update

# How Has This Been Tested?

Compiled sphinx documentation locally.

**Test Configuration**:
* Operating system: MacOS
* Python version number: 3.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
