### PR TITLE
Add description of Anaconda Intel/M1 issue

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -215,6 +215,20 @@ encountered when using clang for ``CC`` alongside gfortran.  This resulted in a
 seemly successful installation with :py:mod:`apexpy` reporting that fortranapex
 cannot be imported.
 
+Some users have reported unusual behavior when using Anaconda on Apple Silicon
+systems.  Anaconda will attempt to build and install the Intel versions of
+wheels instead of the M1 versions and run everything through Rosetta.  This
+configuration has not been fully evaluated, but it results in a seemly
+successful installation with :py:mod:`apexpy` reporting that fortranapex
+cannot be imported.  Users should confirm that wheels created by conda (both for
+apexpy and other packages) end in ``arm64.whl`` not ``osx-64.whl``.  If the
+later is true, users should consider uninstalling anaconda completely, and
+instead installing miniconda following
+`these instructions <https://conda.io/projects/conda/en/stable/user-guide/install/macos.html>`_,
+which has been confirmed to work. **WARNING:** This will remove any environments
+you have set up and likely undo all IDE settings, so be cautious and consider
+backing up your work first!
+
 
 Windows systems are known to have issues with Fortran-based codes.  The Windows
 testing we do uses miniconda, so we recommend using the Anaconda environment.


### PR DESCRIPTION

Description
===========

Add a paragraph to installation documentation page explaining issue where Anacoda on MacOS may try to install the Intel version of packages on M1 system and run things through Rosetta, which fails for unknown reasons.  Current recommendation is to switch to using miniconda if this happens, which seems to manage the installation without issue.  This is probably not really an apexpy problem, but we'll make a note of it in case other users encounter the same issue.  More work could be done to investigate why Anaconda running through Rosetta generates an issue, but this is likely a rare edge case.


Type of change
--------------

* This change is a documentation update


Checklist
---------
- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
