### PR TITLE
Use importlib to track data files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 * Added a logo
 * Correct indexing bug in Fortran source that was causing array overflow and
   memory errors for extrapolated years beyond the latest formal IGRF fit
+* Migrate to using importlib to keep track of pacage data files
 
 2.0.0 (2022-12-09)
 ------------------

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -86,16 +86,6 @@ class Apex(object):
 
     def __init__(self, date=None, refh=0, datafile=None, fortranlib=None):
 
-#        if datafile is None:
-#            datafile0 = os.path.join(os.path.dirname(__file__), 'apexsh.dat')
-#            datafile = files('apexpy').joinpath('apexsh.dat')
-#        print(datafile0, datafile)
-#
-#        if fortranlib is None:
-#            fortranlib = fa.__file__
-
-
-
         self.RE = 6371.009  # Mean Earth radius in km
         self.set_refh(refh)  # Reference height in km
 
@@ -110,14 +100,16 @@ class Apex(object):
                 # date is probably an int or float; use directly
                 self.year = date
 
+        # If datafile is not specified, use the package default, otherwise
+        #   check that the provided file exists
         if datafile is None:
-#            datafile0 = os.path.join(os.path.dirname(__file__), 'apexsh.dat')
-            datafile = files('apexpy').joinpath('apexsh.dat')
-#        print(datafile0, datafile)
+            datafile = files(__package__).joinpath('apexsh.dat')
         else:
             if not os.path.isfile(datafile):
                 raise IOError('Data file does not exist: {}'.format(datafile))
 
+        # If fortranlib is not specified, use the package default, otherwise
+        #   check that the provided file exists
         if fortranlib is None:
             fortranlib = fa.__file__
         else:
@@ -129,11 +121,7 @@ class Apex(object):
         self.fortranlib = fortranlib
 
         # Set the IGRF coefficient text file name
-#        self.igrf_fn = os.path.join(os.path.dirname(__file__),
-#                                    'igrf13coeffs.txt')
-        self.igrf_fn = files('apexpy').joinpath('igrf13coeffs.txt')
-       # if not os.path.exists(self.igrf_fn):
-       #     raise OSError("File {} does not exist".format(self.igrf_fn))
+        self.igrf_fn = files(__package__).joinpath('igrf13coeffs.txt')
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -5,7 +5,6 @@ import datetime as dt
 import numpy as np
 import os
 import warnings
-import sys
 from importlib import resources
 
 from apexpy import helpers
@@ -101,7 +100,8 @@ class Apex(object):
         # If datafile is not specified, use the package default, otherwise
         #   check that the provided file exists
         if datafile is None:
-            datafile = str(resources.path(__package__, 'apexsh.dat').__enter__())
+            datafile = str(resources.path(__package__,
+                                          'apexsh.dat').__enter__())
         else:
             if not os.path.isfile(datafile):
                 raise IOError('Data file does not exist: {}'.format(datafile))
@@ -119,7 +119,8 @@ class Apex(object):
         self.fortranlib = fortranlib
 
         # Set the IGRF coefficient text file name
-        self.igrf_fn = str(resources.path(__package__, 'igrf13coeffs.txt').__enter__())
+        self.igrf_fn = str(resources.path(__package__,
+                                          'igrf13coeffs.txt').__enter__())
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -5,6 +5,10 @@ import datetime as dt
 import numpy as np
 import os
 import warnings
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    from importlib_resources import files
 
 from apexpy import helpers
 
@@ -82,11 +86,15 @@ class Apex(object):
 
     def __init__(self, date=None, refh=0, datafile=None, fortranlib=None):
 
-        if datafile is None:
-            datafile = os.path.join(os.path.dirname(__file__), 'apexsh.dat')
+#        if datafile is None:
+#            datafile0 = os.path.join(os.path.dirname(__file__), 'apexsh.dat')
+#            datafile = files('apexpy').joinpath('apexsh.dat')
+#        print(datafile0, datafile)
+#
+#        if fortranlib is None:
+#            fortranlib = fa.__file__
 
-        if fortranlib is None:
-            fortranlib = fa.__file__
+
 
         self.RE = 6371.009  # Mean Earth radius in km
         self.set_refh(refh)  # Reference height in km
@@ -102,21 +110,30 @@ class Apex(object):
                 # date is probably an int or float; use directly
                 self.year = date
 
-        if not os.path.isfile(datafile):
-            raise IOError('Data file does not exist: {}'.format(datafile))
+        if datafile is None:
+#            datafile0 = os.path.join(os.path.dirname(__file__), 'apexsh.dat')
+            datafile = files('apexpy').joinpath('apexsh.dat')
+#        print(datafile0, datafile)
+        else:
+            if not os.path.isfile(datafile):
+                raise IOError('Data file does not exist: {}'.format(datafile))
 
-        if not os.path.isfile(fortranlib):
-            raise IOError('Fortran library does not exist: {}'.format(
-                fortranlib))
+        if fortranlib is None:
+            fortranlib = fa.__file__
+        else:
+            if not os.path.isfile(fortranlib):
+                raise IOError('Fortran library does not exist: {}'.format(
+                    fortranlib))
 
         self.datafile = datafile
         self.fortranlib = fortranlib
 
         # Set the IGRF coefficient text file name
-        self.igrf_fn = os.path.join(os.path.dirname(__file__),
-                                    'igrf13coeffs.txt')
-        if not os.path.exists(self.igrf_fn):
-            raise OSError("File {} does not exist".format(self.igrf_fn))
+#        self.igrf_fn = os.path.join(os.path.dirname(__file__),
+#                                    'igrf13coeffs.txt')
+        self.igrf_fn = files('apexpy').joinpath('igrf13coeffs.txt')
+       # if not os.path.exists(self.igrf_fn):
+       #     raise OSError("File {} does not exist".format(self.igrf_fn))
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 import warnings
 import sys
-if sys.version_info >= (3,9):
+if sys.version_info >= (3, 9):
     from importlib.resources import files
 else:
     from importlib_resources import files

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -122,7 +122,6 @@ class Apex(object):
 
         # Set the IGRF coefficient text file name
         self.igrf_fn = str(files(__package__).joinpath('igrf13coeffs.txt'))
-        print(self.igrf_fn)
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -103,7 +103,7 @@ class Apex(object):
         # If datafile is not specified, use the package default, otherwise
         #   check that the provided file exists
         if datafile is None:
-            datafile = files(__package__).joinpath('apexsh.dat')
+            datafile = str(files(__package__).joinpath('apexsh.dat'))
         else:
             if not os.path.isfile(datafile):
                 raise IOError('Data file does not exist: {}'.format(datafile))
@@ -121,7 +121,8 @@ class Apex(object):
         self.fortranlib = fortranlib
 
         # Set the IGRF coefficient text file name
-        self.igrf_fn = files(__package__).joinpath('igrf13coeffs.txt')
+        self.igrf_fn = str(files(__package__).joinpath('igrf13coeffs.txt'))
+        print(self.igrf_fn)
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -5,9 +5,10 @@ import datetime as dt
 import numpy as np
 import os
 import warnings
-try:
+import sys
+if sys.version_info >= (3,9):
     from importlib.resources import files
-except ModuleNotFoundError:
+else:
     from importlib_resources import files
 
 from apexpy import helpers

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -6,10 +6,7 @@ import numpy as np
 import os
 import warnings
 import sys
-if sys.version_info >= (3, 9):
-    from importlib.resources import files
-else:
-    from importlib_resources import files
+from importlib import resources
 
 from apexpy import helpers
 
@@ -104,7 +101,7 @@ class Apex(object):
         # If datafile is not specified, use the package default, otherwise
         #   check that the provided file exists
         if datafile is None:
-            datafile = str(files(__package__).joinpath('apexsh.dat'))
+            datafile = str(resources.path(__package__, 'apexsh.dat').__enter__())
         else:
             if not os.path.isfile(datafile):
                 raise IOError('Data file does not exist: {}'.format(datafile))
@@ -122,7 +119,7 @@ class Apex(object):
         self.fortranlib = fortranlib
 
         # Set the IGRF coefficient text file name
-        self.igrf_fn = str(files(__package__).joinpath('igrf13coeffs.txt'))
+        self.igrf_fn = str(resources.path(__package__, 'igrf13coeffs.txt').__enter__())
 
         # Update the Fortran epoch using the year defined above
         self.set_epoch(self.year)

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -18,56 +18,8 @@ import os
 import pytest
 import shutil
 import warnings
-try:
-    from importlib.resources import files
-except ModuleNotFoundError:
-    from importlib_resources import files
 
 import apexpy
-
-
-#def igrf_file(max_attempts=100):
-#    """A fixture for handling the coefficient file.
-#
-#    Parameters
-#    ----------
-#    max_attempts : int
-#        Maximum rename attemps, needed for Windows (default=100)
-#
-#    """
-#    # Ensure the coefficient file exists
-#    original_file = os.path.join(os.path.dirname(apexpy.helpers.__file__),
-#                                 'igrf13coeffs.txt')
-#    tmp_file = "temp_coeff.txt"
-#    assert os.path.isfile(original_file)
-#
-#    # Move the coefficient file
-#    for _ in range(max_attempts):
-#        try:
-#            shutil.move(original_file, tmp_file)
-#            break
-#        except Exception:
-#            pass
-#    yield original_file
-#
-#    # Move the coefficient file back
-#    for _ in range(max_attempts):
-#        try:
-#            shutil.move(tmp_file, original_file)
-#            break
-#        except Exception:
-#            pass
-#    return
-
-
-#def test_set_epoch_file_error(igrf_file):
-#    """Test raises OSError when IGRF coefficient file is missing."""
-#    # Test missing coefficient file failure
-#    with pytest.raises(OSError) as oerr:
-#        apexpy.Apex()
-#    error_string = "File {:} does not exist".format(igrf_file)
-#    assert str(oerr.value).startswith(error_string)
-#    return
 
 
 class TestApexInit(object):
@@ -203,17 +155,17 @@ class TestApexInit(object):
         return
 
     def copy_file(self, original, max_attempts=100):
-        
+        """Make a temporary copy of input file."""
         _, ext = os.path.splitext(original)
-        temp_file = 'temp'+ext
-        
+        temp_file = 'temp' + ext
+
         for _ in range(max_attempts):
             try:
                 shutil.copy(original, temp_file)
                 break
             except Exception:
                 pass
-        
+
         return temp_file
 
     def test_default_datafile(self):
@@ -254,7 +206,7 @@ class TestApexInit(object):
 
     def test_custom_fortranlib(self):
         """Test that the class initializes with a good fortranlib input."""
- 
+
         # Get the original fortranlib name
         apex_out_orig = apexpy.Apex()
         original_lib = apex_out_orig.fortranlib
@@ -281,7 +233,7 @@ class TestApexInit(object):
         apex_out = apexpy.Apex()
         assert os.path.isfile(apex_out.igrf_fn)
         return
-    
+
     def test_repr_eval(self):
         """Test the Apex.__repr__ results."""
         # Initialize the apex object

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -26,43 +26,6 @@ except ModuleNotFoundError:
 import apexpy
 
 
-<<<<<<< HEAD
-@pytest.fixture()
-def igrf_file(max_attempts=100):
-    """A fixture for handling the coefficient file.
-
-    Parameters
-    ----------
-    max_attempts : int
-        Maximum rename attemps, needed for Windows (default=100)
-
-    """
-    # Ensure the coefficient file exists
-    original_file = os.path.join(os.path.dirname(apexpy.helpers.__file__),
-        'igrf13coeffs.txt')
-    #original_file = file(apexpy).joinpath('igrf13coeffs.txt')
-    tmp_file = "temp_coeff.txt"
-    assert os.path.isfile(original_file)
-
-    # Move the coefficient file
-    for _ in range(max_attempts):
-        try:
-            shutil.move(original_file, tmp_file)
-            break
-        except Exception:
-            pass
-    yield original_file
-
-    # Move the coefficient file back
-    for _ in range(max_attempts):
-        try:
-            shutil.move(tmp_file, original_file)
-            break
-        except Exception:
-            pass
-    return
-=======
-#@pytest.fixture()
 #def igrf_file(max_attempts=100):
 #    """A fixture for handling the coefficient file.
 #
@@ -95,7 +58,6 @@ def igrf_file(max_attempts=100):
 #        except Exception:
 #            pass
 #    return
->>>>>>> develop
 
 
 #def test_set_epoch_file_error(igrf_file):

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -31,10 +31,12 @@ class TestApexInit(object):
         self.test_date = dt.datetime.utcnow()
         self.test_refh = 0
         self.bad_file = 'foo/path/to/datafile.blah'
+        self.temp_file = None
 
     def teardown_method(self):
         """Clean up after each test."""
-        del self.apex_out, self.test_date, self.test_refh, self.bad_file
+        del self.apex_out, self.test_date, self.test_refh, self.bad_file, \
+            self.temp_file
 
     def eval_date(self):
         """Evaluate the times in self.test_date and self.apex_out."""
@@ -157,21 +159,21 @@ class TestApexInit(object):
     def copy_file(self, original, max_attempts=100):
         """Make a temporary copy of input file."""
         _, ext = os.path.splitext(original)
-        temp_file = 'temp' + ext
+        self.temp_file = 'temp' + ext
 
         for _ in range(max_attempts):
             try:
-                shutil.copy(original, temp_file)
+                shutil.copy(original, self.temp_file)
                 break
             except Exception:
                 pass
 
-        return temp_file
+        return
 
     def test_default_datafile(self):
         """Test that the class initializes with the default datafile."""
-        apex_out = apexpy.Apex()
-        assert os.path.isfile(apex_out.datafile)
+        self.apex_out = apexpy.Apex()
+        assert os.path.isfile(self.apex_out.datafile)
         return
 
     def test_custom_datafile(self):
@@ -183,12 +185,11 @@ class TestApexInit(object):
         del apex_out_orig
 
         # Create copy of datafile
-        custom_file = self.copy_file(original_file)
+        self.copy_file(original_file)
 
-        apex_out = apexpy.Apex(datafile=custom_file)
-        assert apex_out.datafile == custom_file
+        self.apex_out = apexpy.Apex(datafile=self.temp_file)
+        assert self.apex_out.datafile == self.temp_file
 
-        os.remove(custom_file)
         return
 
     def test_init_with_bad_datafile(self):
@@ -200,8 +201,8 @@ class TestApexInit(object):
 
     def test_default_fortranlib(self):
         """Test that the class initializes with the default fortranlib."""
-        apex_out = apexpy.Apex()
-        assert os.path.isfile(apex_out.fortranlib)
+        self.apex_out = apexpy.Apex()
+        assert os.path.isfile(self.apex_out.fortranlib)
         return
 
     def test_custom_fortranlib(self):
@@ -213,12 +214,11 @@ class TestApexInit(object):
         del apex_out_orig
 
         # Create copy of datafile
-        custom_lib = self.copy_file(original_lib)
+        self.copy_file(original_lib)
 
-        apex_out = apexpy.Apex(fortranlib=custom_lib)
-        assert apex_out.fortranlib == custom_lib
+        self.apex_out = apexpy.Apex(fortranlib=self.temp_file)
+        assert self.apex_out.fortranlib == self.temp_file
 
-        os.remove(custom_lib)
         return
 
     def test_init_with_bad_fortranlib(self):
@@ -230,8 +230,8 @@ class TestApexInit(object):
 
     def test_igrf_fn(self):
         """Test the default igrf_fn."""
-        apex_out = apexpy.Apex()
-        assert os.path.isfile(apex_out.igrf_fn)
+        self.apex_out = apexpy.Apex()
+        assert os.path.isfile(self.apex_out.igrf_fn)
         return
 
     def test_repr_eval(self):

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -18,6 +18,10 @@ import os
 import pytest
 import shutil
 import warnings
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    from importlib_resources import files
 
 import apexpy
 
@@ -34,7 +38,8 @@ def igrf_file(max_attempts=100):
     """
     # Ensure the coefficient file exists
     original_file = os.path.join(os.path.dirname(apexpy.helpers.__file__),
-                                 'igrf13coeffs.txt')
+        'igrf13coeffs.txt')
+    #original_file = file(apexpy).joinpath('igrf13coeffs.txt')
     tmp_file = "temp_coeff.txt"
     assert os.path.isfile(original_file)
 

--- a/apexpy/tests/test_fortranapex.py
+++ b/apexpy/tests/test_fortranapex.py
@@ -14,6 +14,10 @@ These results are expected to change when IGRF is updated.
 
 from numpy.testing import assert_allclose
 import os
+try:
+    from importlib.resources import files
+except ModuleNotFoundError:
+    from importlib_resources import files
 import pytest
 
 import apexpy
@@ -25,8 +29,9 @@ class TestFortranApex(object):
 
     def setup_method(self):
         """Initialize each test."""
-        fa.loadapxsh(os.path.join(os.path.dirname(apexpy.__file__),
-                                  'apexsh.dat'), 2000)
+        #fa.loadapxsh(os.path.join(os.path.dirname(apexpy.__file__),
+        #                          'apexsh.dat'), 2000)
+        fa.loadapxsh(files(apexpy).joinpath('apexsh.dat'), 2000)
 
         # Set the inputs
         self.lat = 60

--- a/apexpy/tests/test_fortranapex.py
+++ b/apexpy/tests/test_fortranapex.py
@@ -14,7 +14,7 @@ These results are expected to change when IGRF is updated.
 
 from numpy.testing import assert_allclose
 import sys
-if sys.version_info >= (3,9):
+if sys.version_info >= (3, 9):
     from importlib.resources import files
 else:
     from importlib_resources import files

--- a/apexpy/tests/test_fortranapex.py
+++ b/apexpy/tests/test_fortranapex.py
@@ -13,9 +13,10 @@ These results are expected to change when IGRF is updated.
 """
 
 from numpy.testing import assert_allclose
-try:
+import sys
+if sys.version_info >= (3,9):
     from importlib.resources import files
-except ModuleNotFoundError:
+else:
     from importlib_resources import files
 import pytest
 

--- a/apexpy/tests/test_fortranapex.py
+++ b/apexpy/tests/test_fortranapex.py
@@ -13,11 +13,7 @@ These results are expected to change when IGRF is updated.
 """
 
 from numpy.testing import assert_allclose
-import sys
-if sys.version_info >= (3, 9):
-    from importlib.resources import files
-else:
-    from importlib_resources import files
+from importlib import resources
 import pytest
 
 import apexpy
@@ -29,7 +25,8 @@ class TestFortranApex(object):
 
     def setup_method(self):
         """Initialize each test."""
-        fa.loadapxsh(files(apexpy).joinpath('apexsh.dat'), 2000)
+        datafile = str(resources.path(apexpy, 'apexsh.dat').__enter__())
+        fa.loadapxsh(datafile, 2000)
 
         # Set the inputs
         self.lat = 60

--- a/apexpy/tests/test_fortranapex.py
+++ b/apexpy/tests/test_fortranapex.py
@@ -13,7 +13,6 @@ These results are expected to change when IGRF is updated.
 """
 
 from numpy.testing import assert_allclose
-import os
 try:
     from importlib.resources import files
 except ModuleNotFoundError:
@@ -29,8 +28,6 @@ class TestFortranApex(object):
 
     def setup_method(self):
         """Initialize each test."""
-        #fa.loadapxsh(os.path.join(os.path.dirname(apexpy.__file__),
-        #                          'apexsh.dat'), 2000)
         fa.loadapxsh(files(apexpy).joinpath('apexsh.dat'), 2000)
 
         # Set the inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 	 "python-dev-tools",
 	 "oldest-supported-numpy; python_version>'3.9'",
 	 "numpy; python_version<='3.9'",
-	 "importlib-resources; python_verson<'3.7'"
+	 "importlib-resources; python_version<'3.7'"
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,12 @@
 build-backend = 'mesonpy'
 requires = [
 	 "wheel",
-	 "meson-python>=0.8.0",
+	 "meson-python>=0.12.0",
 	 "setuptools<60.0",  # Do not increase, 60.0 enables vendored distutils
 	 "Cython>=0.29.21",
 	 "python-dev-tools",
 	 "oldest-supported-numpy; python_version>'3.9'",
-	 "numpy; python_version<='3.9'",
-	 "importlib-resources; python_version<'3.9'"
+	 "numpy; python_version<='3.9'"
 ]
 
 [project]
@@ -23,6 +22,7 @@ dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
     "numpy>=1.19.5",
+    "importlib-resources; python_version<'3.9'"
 ]
 readme = "README.rst"
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
 	 "Cython>=0.29.21",
 	 "python-dev-tools",
 	 "oldest-supported-numpy; python_version>'3.9'",
-	 "numpy; python_version<='3.9'"
+	 "numpy; python_version<='3.9'",
+	 "importlib-resources; python_verson<'3.7'"
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 	 "python-dev-tools",
 	 "oldest-supported-numpy; python_version>'3.9'",
 	 "numpy; python_version<='3.9'",
-	 "importlib-resources; python_version<'3.7'"
+	 "importlib-resources; python_version<'3.9'"
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
     "numpy>=1.19.5",
-    "importlib-resources; python_version<'3.9'"
 ]
 readme = "README.rst"
 keywords = [


### PR DESCRIPTION
Description
===========

This PR transitions to using [importlib.resources](https://docs.python.org/3/library/importlib.resources.html) to keep track of data files instead of paths relative to the source file.  This is the new recommended way of managing package data, as shown in [this description of packaging data](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime) and [this example](https://importlib-resources.readthedocs.io/en/latest/using.html#example).

Type of change
--------------

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that changes existing functionality) - seems to break some unit tests; this is a work in progress

How Has This Been Tested?
-------------------------
Running unit tests - not fully functional yet.

### Test Configuration

* Operating system: MacOS 12.6.1
* Python version number: 3.10
* Compiler with version number: gfortran 12.2.0
* Relevant local setup details: apexpy 2.0.0

Checklist
---------
- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
