### PR TITLE
Temporary fix for version dependency issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,20 @@ jobs:
       run: pip install .[test]
 
     - name: Install on MacOS
-      if: contains(${{ matrix.os }}, 'macos')
+      if: ${{ matrix.os }} == 'macos-13'
       run: |
           brew reinstall gcc@13
-          brew install gfortran
-          ls /usr/local/bin/gcc*
-          CC=/usr/local/bin/gcc-13 pip install .[test]
+          brew reinstall gfortran@13
+          ls /usr/local/bin/gfortran*
+          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran-13 pip install .[test]
+
+    - name: Install on MacOS
+      if: ${{ matrix.os }} == 'macos-latest'
+      run: |
+          brew reinstall gcc@14
+          brew reinstall gfortran@14
+          ls /opt/homebrew/bin/gcc*
+          CC=/opt/homebrew/bin/gcc-14 pip install .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
            echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
            gfortran --version
            pip install flake8 meson-python pytest pytest-cov pytest-xdist scipy
-           pip install numpy>=1.19.5,<2
+           pip install "numpy>=1.19.5,<2"
 
     - name: Install on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -67,14 +67,14 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           pytest --rcfile=apexpy/setup.cfg --cov-report xml
+           pytest --rootdir=apexpy --cov-report xml
            mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           pytest --rcfile=apexpy\setup.cfg --cov-report xml
+           pytest --rootdir=apexpy --cov-report xml
            mv *.xml apexpy\.
 
     - name: Publish results to coveralls upon success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report xml
-           ls *.xml apexpy/*.xml
+           ls *.* .* apexpy/*.* apexpy/.*
            mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,8 +82,8 @@ jobs:
            cd ..
            python -m pytest --rootdir=apexpy --cov-report=xml:coverage.xml
            pwd
-           ls *
-           ls apexpy/*
+           ls -a
+           ls -a apexpy
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,9 @@ jobs:
       run: |
            cd ..
            python -m pytest --rootdir=apexpy --cov-report=xml:coverage.xml
-	   pwd
+           pwd
            ls *
-	   ls apexpy/*
+           ls apexpy/*
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,13 +80,14 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report xml
+           pytest --rootdir=apexpy --cov-report=xml:apexpy/coverage.xml
+	   ls apexpy/coverage.xml
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report xml
+           pytest --rootdir=apexpy --cov-report=xml:apexpy\coverage.xml
 
     - name: Publish results to coveralls upon success
       uses: coverallsapp/github-action@v2
@@ -95,7 +96,6 @@ jobs:
         flag-name: run=${{ join(matrix.*, '-') }}
         parallel: true
         format: cobertura
-        base-path: ..
 
     - name: Create a Windows wheel
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           coverage run --rcfile=apexpy/setup.cfg -m pytest
+           coverage run -m pytest
            coverage report
            coverage xml
            mv coverage.xml apexpy/.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report=xml:apexpy/coverage.xml
-	   ls apexpy/coverage.xml
+           ls apexpy/coverage.xml
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report xml
+	   ls *.xml apexpy/*.xml
            mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,15 +54,13 @@ jobs:
       if: ${{ matrix.os }} == 'macos-13'
       run: |
           brew reinstall gcc@13
-          brew reinstall gfortran@13
           ls /usr/local/bin/gfortran*
-          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran-13 pip install .[test]
+          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran pip install .[test]
 
     - name: Install on MacOS
       if: ${{ matrix.os }} == 'macos-latest'
       run: |
           brew reinstall gcc@14
-          brew reinstall gfortran@14
           ls /opt/homebrew/bin/gcc*
           CC=/opt/homebrew/bin/gcc-14 pip install .[test]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,14 +80,14 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report=xml:apexpy/coverage.xml
-           ls apexpy/coverage.xml
+           pytest --rootdir=apexpy --cov-report=xml:coverage.xml
+           ls *
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report=xml:apexpy\coverage.xml
+           pytest --rootdir=apexpy --cov-report=xml:coverage.xml
 
     - name: Publish results to coveralls upon success
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc
-          CC=/usr/local/bin/gcc-12 python -m build .[test]
-          CC=/usr/local/bin/gcc-12 pip install .[test]
+          CC=/usr/local/bin/gcc python -m build .[test]
+          CC=/usr/local/bin/gcc pip install .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,16 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
 
     - name: Install standard and test dependencies on Mac/Linux
       if: ${{ matrix.os != 'windows-latest' }}
-      run: pip install build coverage coveralls flake8 numpy pytest
+      run: pip install build
 
     - name: Install standard and test dependencies on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -40,20 +40,21 @@ jobs:
            choco install rtools --no-progress
            echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
            gfortran --version
-           pip install coverage coveralls flake8 meson-python numpy pytest scipy
+           pip install flake8 meson-python pytest pytest-cov pytest-xdist scipy
+           pip install numpy>=1.19.5,<2
 
     - name: Install on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-          python -m build .
-          pip install .
+          python -m build .[test]
+          pip install .[test]
 
     - name: Install on MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc
-          CC=/usr/local/bin/gcc-12 python -m build .
-          CC=/usr/local/bin/gcc-12 pip install .
+          CC=/usr/local/bin/gcc-12 python -m build .[test]
+          CC=/usr/local/bin/gcc-12 pip install .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -73,33 +74,23 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           coverage run --rcfile=apexpy/setup.cfg -m pytest
+           pytest --rcfile=apexpy/setup.cfg --cov-report xml
+           mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           coverage run --rcfile=apexpy\setup.cfg -m pytest
+           pytest --rcfile=apexpy\setup.cfg --cov-report xml
+           mv *.xml apexpy\.
 
-    - name: Publish results to coveralls upon success on Mac/Linux
-      if: ${{ matrix.os != 'windows-latest' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-           cd ..
-           coverage combine
-           coverage report -m
-           coveralls --rcfile=apexpy/setup.cfg --service=github
-
-    - name: Publish results to coveralls upon success on Windows
-      if: ${{ matrix.os == 'windows-latest' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-           cd ..
-           coverage combine
-           coverage report -m
-           coveralls --rcfile=apexpy\setup.cfg --service=github
+    - name: Publish results to coveralls upon success
+      uses: coverallsapp/github-actions@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run=${{ join(matrix.*, '-') }}
+        parallel: true
+        format: cobertura
 
     - name: Create a Windows wheel
       if: ${{ matrix.os == 'windows-latest' }}
@@ -112,3 +103,15 @@ jobs:
       with:
          path: dist/*.whl
          if-no-files-found: warn
+
+  finish:
+    name: Finish Coverage Analysis
+    needs: build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
         include:
-          # MacOS latest does not support 3.9, 3.10
           -python-version: "3.9"
            os: "macos-13"
           -python-version: "3.10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
         flag-name: run=${{ join(matrix.*, '-') }}
         parallel: true
         format: cobertura
+	base-path: ..
 
     - name: Create a Windows wheel
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
           brew reinstall gcc@13
           ls /usr/local/bin/gfortran*
-          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran pip install .[test]
+          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran-13 pip install .[test]
 
     - name: Install on MacOS-Latest
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,10 +80,11 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           python -m pytest --rootdir=apexpy --cov-report=xml:coverage.xml
+           python -m pytest --cov-report=xml:coverage.xml
            pwd
            ls -a
            ls -a apexpy
+	   ls -a apexpy/.pytest_cache
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,16 +83,16 @@ jobs:
            coverage run --rcfile=apexpy/setup.cfg -m pytest
            coverage report
            coverage xml
-           pwd
-           ls -a
-           ls -a apexpy
-           ls -a .pytest_cache
+	   mv coverage.xml apexpy/.
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report=xml:coverage.xml
+           coverage run --rcfile=apexpy\setup.cfg -m pytest
+           coverage report
+           coverage xml
+	   mv coverage.xml apexpy\.
 
     - name: Publish results to coveralls upon success
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
+        test_config: ["latest"]
         include:
           -python-version: "3.9"
            os: "macos-13"
+           test_config: ["macos-3.9"]
           -python-version: "3.10"
            os: "macos-13"
+           test_config: ["macos-3.10"]
           -python-version: "3.11"
            os: "macos-latest"
+           test_config: ["macos-3.11"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
            coverage run --rcfile=apexpy/setup.cfg -m pytest
            coverage report
            coverage xml
-	   mv coverage.xml apexpy/.
+           mv coverage.xml apexpy/.
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -92,7 +92,7 @@ jobs:
            coverage run --rcfile=apexpy\setup.cfg -m pytest
            coverage report
            coverage xml
-	   mv coverage.xml apexpy\.
+           mv coverage.xml apexpy\.
 
     - name: Publish results to coveralls upon success
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install on MacOS
-      if: ${{ containsValue(matrix.os, 'macos') }}
+      if: contains(${{ matrix.os }}, 'macos')
       run: |
           brew reinstall gcc-14
           CC=/usr/local/bin/gcc-14 pip install .[test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11"]
+        include:
+          # MacOS latest does not support 3.9, 3.10
+          -python-version: "3.9"
+           os: macos-13
+          -python-version: "3.10"
+           os: macos-13
+          -python-version: "3.11"
+           os: macos-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -46,8 +54,8 @@ jobs:
     - name: Install on MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-          brew reinstall gcc
-          CC=/usr/local/bin/gcc pip install .[test]
+          brew reinstall gcc-14
+          CC=/usr/local/bin/gcc-14 pip install .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
-           coverage run --rcfile=apexpy\setup.cfg -m pytest
+           coverage run -m pytest
            coverage report
            coverage xml
            mv coverage.xml apexpy\.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,15 +81,12 @@ jobs:
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report xml
-           ls *.* .* apexpy/*.* apexpy/.*
-           mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report xml
-           mv *.xml apexpy\.
 
     - name: Publish results to coveralls upon success
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
           brew reinstall gcc@13
           brew install gfortran
-	  ls /usr/local/bin/gcc*
+          ls /usr/local/bin/gcc*
           CC=/usr/local/bin/gcc-13 pip install .[test]
 
     - name: Install on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
            mv *.xml apexpy\.
 
     - name: Publish results to coveralls upon success
-      uses: coverallsapp/github-actions@v2
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: run=${{ join(matrix.*, '-') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
         flag-name: run=${{ join(matrix.*, '-') }}
         parallel: true
         format: cobertura
-	base-path: ..
+        base-path: ..
 
     - name: Create a Windows wheel
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,17 +18,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
-        test_config: ["latest"]
         include:
-          -python-version: "3.9"
-           os: "macos-13"
-           test_config: ["macos-3.9"]
-          -python-version: "3.10"
-           os: "macos-13"
-           test_config: ["macos-3.10"]
-          -python-version: "3.11"
-           os: "macos-latest"
-           test_config: ["macos-3.11"]
+          - python-version: "3.9"
+            os: "macos-13"
+          - python-version: "3.10"
+            os: "macos-13"
+          - python-version: "3.11"
+            os: "macos-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -55,7 +51,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install on MacOS
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ containsValue(matrix.os, 'macos') }}
       run: |
           brew reinstall gcc-14
           CC=/usr/local/bin/gcc-14 pip install .[test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,15 +50,15 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: pip install .[test]
 
-    - name: Install on MacOS
-      if: ${{ matrix.os }} == 'macos-13'
+    - name: Install on MacOS-13
+      if: ${{ matrix.os == 'macos-13' }}
       run: |
           brew reinstall gcc@13
           ls /usr/local/bin/gfortran*
           CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran pip install .[test]
 
-    - name: Install on MacOS
-      if: ${{ matrix.os }} == 'macos-latest'
+    - name: Install on MacOS-Latest
+      if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc@14
           ls /opt/homebrew/bin/gcc*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
 
-    - name: Install standard and test dependencies on Mac/Linux
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: pip install build
-
-    - name: Install standard and test dependencies on Windows
+    - name: Install Windows-specific dependencies for non-pip install
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
            choco install ninja mingw
@@ -45,15 +41,12 @@ jobs:
 
     - name: Install on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-          python -m build .[test]
-          pip install .[test]
+      run: pip install .[test]
 
     - name: Install on MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc
-          CC=/usr/local/bin/gcc python -m build .[test]
           CC=/usr/local/bin/gcc pip install .[test]
 
     - name: Install on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,11 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           python -m pytest --cov-report=xml:coverage.xml
+           python -m pytest --cov-report=xml
            pwd
            ls -a
            ls -a apexpy
-           ls -a apexpy/.pytest_cache
+           ls -a .pytest_cache
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
         include:
           # MacOS latest does not support 3.9, 3.10
           -python-version: "3.9"
-           os: macos-13
+           os: "macos-13"
           -python-version: "3.10"
-           os: macos-13
+           os: "macos-13"
           -python-version: "3.11"
-           os: macos-latest
+           os: "macos-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
     - name: Install on MacOS
       if: contains(${{ matrix.os }}, 'macos')
       run: |
-          brew reinstall gcc-14
-          CC=/usr/local/bin/gcc-14 pip install .[test]
+          brew reinstall gcc@13
+          CC=/usr/local/bin/gcc-13 pip install .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,10 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           pytest --rootdir=apexpy --cov-report=xml:coverage.xml
+           python -m pytest --rootdir=apexpy --cov-report=xml:coverage.xml
+	   pwd
            ls *
+	   ls apexpy/*
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
            cd ..
            pytest --rootdir=apexpy --cov-report xml
-	   ls *.xml apexpy/*.xml
+           ls *.xml apexpy/*.xml
            mv *.xml apexpy/.
 
     - name: Run unit and integration tests on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,8 @@ jobs:
       if: contains(${{ matrix.os }}, 'macos')
       run: |
           brew reinstall gcc@13
+          brew install gfortran
+	  ls /usr/local/bin/gcc*
           CC=/usr/local/bin/gcc-13 pip install .[test]
 
     - name: Install on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,15 +53,13 @@ jobs:
     - name: Install on MacOS-13
       if: ${{ matrix.os == 'macos-13' }}
       run: |
-          brew reinstall gcc@13
-          ls /usr/local/bin/gfortran*
-          CC=/usr/local/bin/gcc-13 FF=/usr/local/bin/gfortran-13 pip install .[test]
+          brew reinstall gcc@14
+          CC=/usr/local/bin/gcc-14 pip install .[test]
 
     - name: Install on MacOS-Latest
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc@14
-          ls /opt/homebrew/bin/gcc*
           CC=/opt/homebrew/bin/gcc-14 pip install .[test]
 
     - name: Install on Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
            pwd
            ls -a
            ls -a apexpy
-	   ls -a apexpy/.pytest_cache
+           ls -a apexpy/.pytest_cache
 
     - name: Run unit and integration tests on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,9 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
            cd ..
-           python -m pytest --cov-report=xml
+           coverage run --rcfile=apexpy/setup.cfg -m pytest
+           coverage report
+           coverage xml
            pwd
            ls -a
            ls -a apexpy

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Declare the Python requirements required to build your docs
+# This method includes a local build of the package
+python:
+   install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,10 +15,10 @@ sphinx:
    configuration: docs/conf.py
 
 # Declare the Python requirements required to build your docs
-# This method includes a local build of the package
+# This method avoids a local build of the package
 python:
    install:
     - method: pip
-      path: .
+      path: docs
       extra_requirements:
-        - doc
+        - requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,4 @@ sphinx:
 # This method avoids a local build of the package
 python:
    install:
-    - method: pip
-      path: docs
-      extra_requirements:
-        - requirements.txt
+    - requirements: docs/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+2.0.2 (2024-11-XX)
+------------------
+* Updated supported Python versions (3.9-3.11)
+* Added a ReadTheDocs yaml
+
 2.0.1 (2023-04-11)
 ------------------
 * Expanded installation instructions in the documenation

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -22,49 +22,49 @@ import warnings
 import apexpy
 
 
-@pytest.fixture()
-def igrf_file(max_attempts=100):
-    """A fixture for handling the coefficient file.
+#@pytest.fixture()
+#def igrf_file(max_attempts=100):
+#    """A fixture for handling the coefficient file.
+#
+#    Parameters
+#    ----------
+#    max_attempts : int
+#        Maximum rename attemps, needed for Windows (default=100)
+#
+#    """
+#    # Ensure the coefficient file exists
+#    original_file = os.path.join(os.path.dirname(apexpy.helpers.__file__),
+#                                 'igrf13coeffs.txt')
+#    tmp_file = "temp_coeff.txt"
+#    assert os.path.isfile(original_file)
+#
+#    # Move the coefficient file
+#    for _ in range(max_attempts):
+#        try:
+#            shutil.move(original_file, tmp_file)
+#            break
+#        except Exception:
+#            pass
+#    yield original_file
+#
+#    # Move the coefficient file back
+#    for _ in range(max_attempts):
+#        try:
+#            shutil.move(tmp_file, original_file)
+#            break
+#        except Exception:
+#            pass
+#    return
 
-    Parameters
-    ----------
-    max_attempts : int
-        Maximum rename attemps, needed for Windows (default=100)
 
-    """
-    # Ensure the coefficient file exists
-    original_file = os.path.join(os.path.dirname(apexpy.helpers.__file__),
-                                 'igrf13coeffs.txt')
-    tmp_file = "temp_coeff.txt"
-    assert os.path.isfile(original_file)
-
-    # Move the coefficient file
-    for _ in range(max_attempts):
-        try:
-            shutil.move(original_file, tmp_file)
-            break
-        except Exception:
-            pass
-    yield original_file
-
-    # Move the coefficient file back
-    for _ in range(max_attempts):
-        try:
-            shutil.move(tmp_file, original_file)
-            break
-        except Exception:
-            pass
-    return
-
-
-def test_set_epoch_file_error(igrf_file):
-    """Test raises OSError when IGRF coefficient file is missing."""
-    # Test missing coefficient file failure
-    with pytest.raises(OSError) as oerr:
-        apexpy.Apex()
-    error_string = "File {:} does not exist".format(igrf_file)
-    assert str(oerr.value).startswith(error_string)
-    return
+#def test_set_epoch_file_error(igrf_file):
+#    """Test raises OSError when IGRF coefficient file is missing."""
+#    # Test missing coefficient file failure
+#    with pytest.raises(OSError) as oerr:
+#        apexpy.Apex()
+#    error_string = "File {:} does not exist".format(igrf_file)
+#    assert str(oerr.value).startswith(error_string)
+#    return
 
 
 class TestApexInit(object):
@@ -199,6 +199,43 @@ class TestApexInit(object):
         self.eval_refh()
         return
 
+    def copy_file(self, original, max_attempts=100):
+        
+        _, ext = os.path.splitext(original)
+        temp_file = 'temp'+ext
+        
+        for _ in range(max_attempts):
+            try:
+                shutil.copy(original, temp_file)
+                break
+            except Exception:
+                pass
+        
+        return temp_file
+
+    def test_default_datafile(self):
+        """Test that the class initializes with the default datafile."""
+        apex_out = apexpy.Apex()
+        assert os.path.isfile(apex_out.datafile)
+        return
+
+    def test_custom_datafile(self):
+        """Test that the class initializes with a good datafile input."""
+
+        # Get the original datafile name
+        apex_out_orig = apexpy.Apex()
+        original_file = apex_out_orig.datafile
+        del apex_out_orig
+
+        # Create copy of datafile
+        custom_file = self.copy_file(original_file)
+
+        apex_out = apexpy.Apex(datafile=custom_file)
+        assert apex_out.datafile == custom_file
+
+        os.remove(custom_file)
+        return
+
     def test_init_with_bad_datafile(self):
         """Test raises IOError with non-existent datafile input."""
         with pytest.raises(IOError) as oerr:
@@ -206,13 +243,42 @@ class TestApexInit(object):
         assert str(oerr.value).startswith('Data file does not exist')
         return
 
+    def test_default_fortranlib(self):
+        """Test that the class initializes with the default fortranlib."""
+        apex_out = apexpy.Apex()
+        assert os.path.isfile(apex_out.fortranlib)
+        return
+
+    def test_custom_fortranlib(self):
+        """Test that the class initializes with a good fortranlib input."""
+ 
+        # Get the original fortranlib name
+        apex_out_orig = apexpy.Apex()
+        original_lib = apex_out_orig.fortranlib
+        del apex_out_orig
+
+        # Create copy of datafile
+        custom_lib = self.copy_file(original_lib)
+
+        apex_out = apexpy.Apex(fortranlib=custom_lib)
+        assert apex_out.fortranlib == custom_lib
+
+        os.remove(custom_lib)
+        return
+
     def test_init_with_bad_fortranlib(self):
-        """Test raises IOError with non-existent datafile input."""
+        """Test raises IOError with non-existent fortranlib input."""
         with pytest.raises(IOError) as oerr:
             apexpy.Apex(fortranlib=self.bad_file)
         assert str(oerr.value).startswith('Fortran library does not exist')
         return
 
+    def test_igrf_fn(self):
+        """Test the default igrf_fn."""
+        apex_out = apexpy.Apex()
+        assert os.path.isfile(apex_out.igrf_fn)
+        return
+    
     def test_repr_eval(self):
         """Test the Apex.__repr__ results."""
         # Initialize the apex object

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -168,7 +168,7 @@ class TestApexInit(object):
             except Exception:
                 pass
 
-        return
+        return self.temp_file
 
     def test_default_datafile(self):
         """Test that the class initializes with the default datafile."""

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -235,7 +235,7 @@ class TestApexInit(object):
         apex_out = apexpy.Apex()
         assert os.path.isfile(apex_out.igrf_fn)
         return
-    
+
     def test_repr_eval(self):
         """Test the Apex.__repr__ results."""
         # Initialize the apex object

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,9 +13,9 @@ The recommended (and most straightforward) method for users to install
 
     pip install apexpy
 
-You should be able to import :py:mod:`apexpy` and run basic conversions as shown in the
-examples.  If you get errors or warnings upon importing, see below for more
-advanced options and troubleshooting.
+You should be able to import :py:mod:`apexpy` and run basic conversions as shown
+in the examples.  If you get errors or warnings upon importing, see below for
+more advanced options and troubleshooting.
 
 
 .. _installation-tested:
@@ -26,7 +26,7 @@ Tested environments
 The package has been tested with the following setups (others might work, too):
 
 * Windows (64 bit Python), Linux (64 bit), and Mac (64 bit)
-* Python 3.7, 3.8, 3.9, 3.10
+* Python 3.9, 3.10, 3.11
 
 Note that :py:mod:`apexpy` is NOT currently compatable with Python 3.12 or 
 `NumPy 2.0 <https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#numpy-2-migration-guide>`_.  

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,6 +28,9 @@ The package has been tested with the following setups (others might work, too):
 * Windows (64 bit Python), Linux (64 bit), and Mac (64 bit)
 * Python 3.7, 3.8, 3.9, 3.10
 
+Note that :py:mod:`apexpy` is NOT currently compatable with Python 3.12 or 
+`NumPy 2.0 <https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#numpy-2-migration-guide>`_.  
+
 
 Advanced Installation
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,10 @@ apexpy = {reference = 'apexpy.__main__:main', type = 'console'}
 
 [project.optional-dependencies]
 test = [
+  "flake8",
   "pytest",
   "pytest-cov",
-  "pytest-xdist",
+  "pytest-xdist"
   ]
 doc = ["sphinx>=1.3", "sphinx-rtd-theme"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ apexpy = {reference = 'apexpy.__main__:main', type = 'console'}
 
 [project.optional-dependencies]
 test = [
+  "coverage",
   "flake8",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "A Python wrapper for Apex coordinates"
 maintainers = [
     {name = "Angeline G. Burrell", email = "angeline.burrell@nrl.navy.mil"},
 ]
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.9,<3.12"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
@@ -43,10 +43,9 @@ classifiers = [
     "Programming Language :: Fortran",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering :: Physics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ description = "A Python wrapper for Apex coordinates"
 maintainers = [
     {name = "Angeline G. Burrell", email = "angeline.burrell@nrl.navy.mil"},
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.7,<3.12"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.19.5",
+    "numpy>=1.19.5,<2",
 ]
 readme = "README.rst"
 keywords = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,9 @@ classifiers =
   Operating System :: MacOS :: MacOS X
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.7
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Programming Language :: Python :: Implementation :: CPython
   Topic :: Scientific/Engineering :: Physics
   Topic :: Utilities


### PR DESCRIPTION
Description
===========

This PR pins the version of numpy and python used in `pyproject.toml` and clarifies in the documentation that `apexpy` is currently not compatible with numpy 2.0 and python 3.12.  A new minor release should be published to help users avoid some confusion with installation issues.

This is a temporary fix for #134 and #135.  These issues should not be closed as more comprehensive fixes should be implemented in the future.


Type of change
--------------

* Bug fix (non-breaking change which fixes an issue)
* Release candidate

How Has This Been Tested?
-------------------------
Installation has been tested in a clean Python 3.11 environment to ensure expected behavior (successful installation of apexpy with numpy 1.26).  Installation in a python 3.12 behavior fails, but it is now documented that apexpy does not support python 3.12.

From apexpy root directory:
```
pip install .
```

### Test Configuration

* Operating system: MacOS
* Python version number: 3.11/3.12
* Compiler with version number: gfortran 13.1.0

Checklist
---------
- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
