### PR TITLE
Numpy 2.X update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.11"]
 
     env:
        FC: gfortran

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,26 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        numpy_ver: ["latest"]
+        test_config: ["latest"]
         include:
+          # Support different GA Mac environmnets
           - python-version: "3.9"
             os: "macos-13"
           - python-version: "3.10"
             os: "macos-13"
           - python-version: "3.11"
             os: "macos-latest"
+          - python-version: "3.12"
+            os: "macos-latest"
+          # NEP29 compliance settings
+          - python-version: "3.10"
+            numpy_ver: "1.25"
+            os: "ubuntu-latest"
+            test_config: "NEP29"
 
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with Numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -44,23 +54,28 @@ jobs:
            echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
            gfortran --version
            pip install flake8 meson-python pytest pytest-cov pytest-xdist scipy
-           pip install "numpy>=1.19.5,<2"
+           pip install "numpy>=1.19.5"
+
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.test_config == 'NEP29'}}
+      run: |
+        pip install numpy==${{ matrix.numpy_ver }}
 
     - name: Install on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: pip install .[test]
+      run: pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install on MacOS-13
       if: ${{ matrix.os == 'macos-13' }}
       run: |
           brew reinstall gcc@14
-          CC=/usr/local/bin/gcc-14 pip install .[test]
+          CC=/usr/local/bin/gcc-14 pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install on MacOS-Latest
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
           brew reinstall gcc@14
-          CC=/opt/homebrew/bin/gcc-14 pip install .[test]
+          CC=/opt/homebrew/bin/gcc-14 pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install on Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 2.1.0 (2024-12-XX)
 ------------------
 * Adapted codebase to read IRGF coefficients from a file (updated to IGRF-14)
+* Updated package to be compliant and installable with numpy 2.0+
+* Added tests for Python 3.12 and NEP29
+* Fixed link to logo in the README
 
 2.0.2 (2024-11-12)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -143,5 +143,5 @@ Badges
 .. |doi| image:: https://www.zenodo.org/badge/doi/10.5281/zenodo.4585641.svg
    :target: https://doi.org/10.5281/zenodo.1214206
 
-.. |logo| image:: docs/apexpy.png
+.. |logo| image:: https://github.com/aburrell/apexpy/blob/main/docs/apexpy.png
    :alt: ApexPy logo: yellow magnetic field lines surrounding the Earth's surface, which is blue

--- a/apexpy/apex.py
+++ b/apexpy/apex.py
@@ -65,7 +65,7 @@ class Apex(object):
 
     Notes
     -----
-    The calculations use IGRF-13 with coefficients from 1900 to 2025 [1]_.
+    The calculations use IGRF-14 with coefficients from 1900 to 2030 [1]_.
 
     The geodetic reference ellipsoid is WGS84.
 
@@ -87,7 +87,8 @@ class Apex(object):
         self.set_refh(refh)  # Reference height in km
 
         if date is None:
-            self.year = helpers.toYearFraction(dt.datetime.utcnow())
+            self.year = helpers.toYearFraction(dt.datetime.now(
+                tz=dt.timezone.utc))
         else:
             try:
                 # Convert date/datetime object to decimal year

--- a/apexpy/tests/test_Apex.py
+++ b/apexpy/tests/test_Apex.py
@@ -1334,7 +1334,7 @@ class TestApexMapMethods(object):
         # Set the base input and output values
         eshape = list(arr_shape)
         eshape.insert(0, 3)
-        edata = np.array([[1, 2, 3]] * np.product(arr_shape)).transpose()
+        edata = np.array([[1, 2, 3]] * np.prod(arr_shape)).transpose()
         in_args = [60, 15, 100, 500, edata.reshape(tuple(eshape))]
 
         # Update inputs for one vectorized value if this is a location input

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,10 +26,7 @@ Tested environments
 The package has been tested with the following setups (others might work, too):
 
 * Windows (64 bit Python), Linux (64 bit), and Mac (64 bit)
-* Python 3.9, 3.10, 3.11
-
-Note that :py:mod:`apexpy` is NOT currently compatable with Python 3.12 or 
-`NumPy 2.0 <https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#numpy-2-migration-guide>`_.  
+* Python 3.9, 3.10, 3.11, and 3.12
 
 
 Advanced Installation

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,23 @@ add_languages('fortran', native: false)
 fc = meson.get_compiler('fortran')
 cc = meson.get_compiler('c')
 
+# https://mesonbuild.com/Python-module.html
+py_mod = import('python')
+py3 = py_mod.find_installation()
+py3_dep = py3.dependency()
+message(py3.full_path())
+message(py3.get_install_dir())
+
+# Determine whether this is being compiled with numpy 1.X or 2.X
+numpy_ver = run_command(py3,
+  ['-c', 'import numpy; print(numpy.__version__.split(".")[0])'],
+  check : true
+).stdout().strip()
+is_numpytwo = numpy_ver.to_int() >= 2
+
+message('The Numpy major version is: ', numpy_ver)
+
+
 # Don't use the deprecated NumPy C API. Define this to a fixed version instead
 # of NPY_API_VERSION in order not to break compilation for released versions
 # when NumPy introduces a new deprecation. Use in a meson.build file::
@@ -28,7 +45,12 @@ cc = meson.get_compiler('c')
 #     'source_fname',
 #     numpy_nodepr_api)
 #
-numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
+if is_numpytwo
+  numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_2_0_API_VERSION'
+else
+  numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
+endif
+
 
 # This argument is called -Wno-unused-but-set-variable by GCC, however Clang
 # doesn't recognize that.
@@ -45,13 +67,6 @@ endif
 # Add more link arguments
 add_project_link_arguments('-lquadmath', language: ['c', 'fortran'])
 
-# https://mesonbuild.com/Python-module.html
-py_mod = import('python')
-py3 = py_mod.find_installation()
-py3_dep = py3.dependency()
-message(py3.full_path())
-message(py3.get_install_dir())
-
 incdir_numpy = run_command(py3,
   ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
   check : true
@@ -64,15 +79,19 @@ incdir_f2py = run_command(py3,
 
 inc_dirs = include_directories(incdir_numpy, incdir_f2py)
 
-# Don't use the deprecated NumPy C API. Define this to a fixed version instead of
-# NPY_API_VERSION in order not to break compilation for released SciPy versions
-# when NumPy introduces a new deprecation. Use in a meson.build file::
+# Don't use the deprecated NumPy C API. Define this to a fixed version instead
+# of NPY_API_VERSION in order not to break compilation for released SciPy
+# versions when NumPy introduces a new deprecation. Use in a meson.build file::
 #
 #   py3.extension_module('_name',
 #     'source_fname',
 #     numpy_nodepr_api)
 #
-c_flags = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
+if is_numpytwo
+  c_flags = ['-DNPY_NO_DEPRECATED_API=NPY_2_0_API_VERSION']
+else
+  c_flags = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
+endif
 
 # Platform detection to set more flags for Windows systems
 is_windows = host_machine.system() == 'windows'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ description = "A Python wrapper for Apex coordinates"
 maintainers = [
     {name = "Angeline Burrell", email = "angeline.g.burrell.civ@us.navy.mil"},
 ]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
-    # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.19.5,<2",
+    # https://github.com/mesonbuild/meson-python/issues/29
+    "numpy>=1.19.5",
 ]
 readme = "README.rst"
 keywords = [
@@ -46,6 +46,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering :: Physics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ requires = [
 	 "setuptools<60.0",  # Do not increase, 60.0 enables vendored distutils
 	 "Cython>=0.29.21",
 	 "python-dev-tools",
-	 "oldest-supported-numpy; python_version>'3.9'",
-	 "numpy; python_version<='3.9'"
+	 "numpy"
 ]
 
 [project]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
   Programming Language :: Python :: Implementation :: CPython
   Topic :: Scientific/Engineering :: Physics
   Topic :: Utilities


### PR DESCRIPTION
Description
===========

Addresses #134 by addressing incompatibilities with numpy 2.X.

Also addresses #140 and #135.

Type of change
--------------
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* This change requires a documentation update


How Has This Been Tested?
-------------------------
With numpy 2.X installed, install and ensure apexpy imports.  If it is compiled with the wrong version of numpy, the crash message will start with:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.1 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
```

### Test Configuration

* Operating system: OS X Ventura
* Python version number: 3.11
* Compiler with version number: gfortran 14.2.0
* Relevant local setup details: this branch
* 
Checklist
---------
- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
