### PR TITLE
BUG: Meson build on windows

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,28 +1,28 @@
 {
   "license": {
   "id": "MIT"
-  }, 
+  },
   "notes": "When referencing this package, please cite both the package DOI and the Apex Coordinates journal article: Emmert, J. T., A. D. Richmond, and D. P. Drob (2010), A computationally compact representation of Magnetic-Apex and Quasi-Dipole coordinates with smooth base vectors, J. Geophys. Res., 115(A8), A08322, doi:10.1029/2010JA015326.",
   "references": [
     "Emmert, J. T., A. D. Richmond, and D. P. Drob (2010), A computationally compact representation of Magnetic-Apex and Quasi-Dipole coordinates with smooth base vectors, J. Geophys. Res., 115(A8), A08322, doi:10.1029/2010JA015326.",
     "Richmond, A. D. (1995), Ionospheric Electrodynamics Using Magnetic Apex Coordinates, Journal of geomagnetism and geoelectricity, 47(2), 191–212, doi:10.5636/jgg.47.191."
-  ], 
+  ],
   "keywords": [
     "Magnetic Apex Coordinates",
     "Quasi Dipole Coordinates",
-    "MLT", 
-    "Magnetic Local Time", 
-    "Conversion", 
-    "Coordinate Conversion", 
-    "Converting", 
-    "Ionosphere", 
-    "Magnetic Field", 
-    "Space Physics", 
+    "MLT",
+    "Magnetic Local Time",
+    "Conversion",
+    "Coordinate Conversion",
+    "Converting",
+    "Ionosphere",
+    "Magnetic Field",
+    "Space Physics",
     "Heliophysics"
-  ], 
+  ],
   "creators": [
     {
-      "orcid": "0000-0002-8043-0953", 
+      "orcid": "0000-0002-8043-0953",
       "name": "van der Meeren, Christer"
     },
     {
@@ -30,8 +30,8 @@
       "name": "Laundal, Karl M."
     },
     {
-      "orcid": "0000-0001-8875-9326", 
-      "affiliation": "Naval Research Laboratory", 
+      "orcid": "0000-0001-8875-9326",
+      "affiliation": "Naval Research Laboratory",
       "name": "Burrell, Angeline G."
     },
     {
@@ -55,6 +55,11 @@
       "orcid": "0000-0001-9741-4063",
       "affiliation": "GFZ German Research Centre for Geosciences",
       "name": "Michaelis, Ingo"
+    },
+    {
+      "orcid": "0000-0001-8321-6074",
+      "affiliation": "Goddard Space Flight Center",
+      "name": "Klenzing, Jeff"
     }
-  ]
+]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -61,5 +61,5 @@
       "affiliation": "Goddard Space Flight Center",
       "name": "Klenzing, Jeff"
     }
-]
+  ]
 }

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ This python wrapper is made by:
 * Ashton Reimer
 * Achim Morschhauser
 * Ingo Michaelis
+* Jeff Klenzing
 
 Fortran code by Emmert et al. [2010] [1]_. Quasi-dipole and modified
 apex coordinates are defined by Richmond [1995] [2]_. The code uses

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 * Fixed the command-line executable
 * Updated code to address deprecation warnings around np.float64 use
 * Updated code to remove use of datetime `utcnow`
+* Updated meson build requirements to include ninja for Windows builds
 
 2.0.2 (2024-11-12)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changelog
 * Fixed the command-line executable
 * Updated code to address deprecation warnings around np.float64 use
 * Updated code to remove use of datetime `utcnow`
-* Updated meson build requirements to include ninja for Windows builds
+* Updated meson build requirements to include ninja for Windows builds instead of python-dev-tools
 
 2.0.2 (2024-11-12)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 	 "meson-python>=0.12.0",
 	 "setuptools<60.0",  # Do not increase, 60.0 enables vendored distutils
 	 "Cython>=0.29.21",
-         "ninja",
+   "ninja",
 	 "numpy"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
 	 "meson-python>=0.12.0",
 	 "setuptools<60.0",  # Do not increase, 60.0 enables vendored distutils
 	 "Cython>=0.29.21",
+         "ninja",
 	 "numpy"
 ]
 


### PR DESCRIPTION
Description
===========

`python-dev-tools` installs numerous linters and subsequent dependencies as part of the package. This includes `fastapi`, which has a broken version installed on test-pypi that will be installed by default when testing pip install from there. However, removing `python-dev-tools` from the meson build will break the windows install (mac and ubuntu are fine).

`ninja` is the primary dependency required for the windows install. This updates the meson requirements accordingly.

Type of change
--------------

* Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
-------------------------
via the main workflow in GitHub Actions

### Test Configuration

* Operating system: ubuntu, mac, windows
* Python version number: 3.9, 3.10, 3.11, 3.12
* Compiler with version number: ??
* Relevant local setup details: GitHub Actions

Checklist
---------
- [rc] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
