### PR TITLE
BUG: GitHub Actions and artifact upload, broken doc links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
     name: Docs ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "0 3 * * 1"  # Runs 03:00 UT on Mondays 
+    - cron: "0 3 * * 1"  # Runs 03:00 UT on Mondays
 
 jobs:
   build:
@@ -87,7 +87,7 @@ jobs:
           meson setup build
           ninja -j 2 -C build
           cd build
-          meson install --destdir=${{ env.Python3_ROOT_DIR }} 
+          meson install --destdir=${{ env.Python3_ROOT_DIR }}
 
     - name: Test PEP8 compliance
       run: flake8 . --count --show-source --statistics
@@ -120,18 +120,6 @@ jobs:
         flag-name: run=${{ join(matrix.*, '-') }}
         parallel: true
         format: cobertura
-
-    - name: Create a Windows wheel
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-           mkdir dist
-           pip wheel . -w dist
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-         path: dist/*.whl
-         if-no-files-found: warn
 
   finish:
     name: Finish Coverage Analysis

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 2.1.1 (2025-XX-XX)
 ------------------
 * Updated GitHub Actions versions and removed unused wheel upload
+* Fixed broken doc link
 
 2.1.0 (2025-01-07)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+2.1.1 (2025-XX-XX)
+------------------
+* Updated GitHub Actions versions and removed unused wheel upload
+
 2.1.0 (2025-01-07)
 ------------------
 * Adapted codebase to read IRGF coefficients from a file (updated to IGRF-14)

--- a/docs/examples/ex_gc.rst
+++ b/docs/examples/ex_gc.rst
@@ -48,7 +48,7 @@ equation layed out in equation 3-28 of Snyder [2]_.
        gd_lat = np.arctan(np.tan(np.radians(gc_lat)) / (1.0 - e_sq))
        return np.degrees(gd_lat)
 
-       
+
 The function above requires the first eccentricity of the reference ellipsoid.
 This example uses the ``pyproj`` library [3]_ to get the WGS84 ellipsoid data,
 but the function shown will take any float.  This lets you decide the level of
@@ -70,7 +70,7 @@ then from apex to quasi-dipole.
 ::
 
    import apexpy
-   
+
    # Define the starting values
    year = 2015.3
    gc_lat = 45.0
@@ -85,9 +85,8 @@ then from apex to quasi-dipole.
 
 
 .. [1] Snay and Soler (1999) Modern Terrestrial Reference Systems (Part 1),
-       `Professional Surveyor <https://www.ngs.noaa.gov/CORS/Articles/
-       Reference-Systems-Part-1.pdf>`_.
+       `Professional Surveyor <https://prltap.org/eng/wp-content/uploads/2016/09/Modern-Terrestrial-Reference-Systems-Part-1-to-Part-4.pdf>`_.
 .. [2] Snyder, J. P. Map projections — A working manual. Professional Paper
        1395, U.S. Geological Survey, 1987.
        `doi:10.3133/pp1395 <https://pubs.er.usgs.gov/publication/pp1395>`_.
-.. [3] `pyproj GitHub page <https://github.com/pyproj4/pyproj>`_.      
+.. [3] `pyproj GitHub page <https://github.com/pyproj4/pyproj>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,30 +107,6 @@ Install against an incompatible numpy version
   pip install apexpy --no-build-isolation --no-cache
 
 
-Installation using CI Wheels
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If your local set up is essentially identical to one of the CI test
-environments, then you can use one of the wheel artifacts to install
-:py:mod:`apexpy`. The list of artifacts may be found
-`here <https://api.github.com/repos/aburrell/apexpy/actions/artifacts>`_.
-
-To download an artifact:
-
-1. If you don't have a GitHub Personal Access Token, follow
-   `these instructions <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
-   to create one.
-2. Run ``curl -v -H "Authorization: token <GITHUB-ACCESS-TOKEN>" https://api.github.com/repos/aburrell/apexpy/actions/artifacts/<ARTIFACT-ID>/zip``, where
-   <ITEM> should be replaced with the appropriate item string.
-3. Copy the URL from the ``Location`` output produced by the previous command
-   into a browser, which will download a zip archive into your standard
-   download location. Alternatively (or if this doesn't work) you can use
-   `wget` to retrieve the archive.
-4. Copy the zip archive into the ``apexpy/dist`` directory and unzip.
-5. Check the archive for the expected matrix of ``*.whl`` objects
-
-To install, use ``pip install .``
-
 .. _installation-build:
 
 Build from Source


### PR DESCRIPTION
Description
===========

The action `upload-artifact@v3` was deprecated earlier this year, breaking the GitHub Actions workflow. According to [this](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), artifact names are now immutable, meaning each must be tagged with a version when uploaded.

After discussion with @aburrell, the upload here was a test to generate a wheel, but the end product was unused. This PR removes the lines from the workflow rather than updating.

Also identified a broken link in the documentation to a publication no longer hosted by NOAA. Options for fixing this discussed below.

Fixes #153

Type of change
--------------
* Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
-------------------------
Inspection of GitHub Actions workflows. Tests now run successfully.

### Test Configuration

* Operating system: mac, ubuntu, windows
* Python version number: 3.9, 3.10, 3.11, 3.12
* Compiler with version number: gfortran 12.2.0
* Relevant local setup details: GitHub Actions

Checklist
---------
- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst`` and ``.zenodo.json``
